### PR TITLE
Add path to exec's

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,7 @@ class graphite::config inherits graphite::params {
 	anchor { 'graphite::config::end': }
 
   Exec {
-    path => '/bin:/usr/bin',
+    path => '/bin:/usr/bin:/usr/sbin',
   }
 
 	# for full functionality we need this packages:

--- a/manifests/install/debian.pp
+++ b/manifests/install/debian.pp
@@ -3,7 +3,7 @@ class graphite::install::debian {
 	require graphite::params
 
   Exec {
-    path => '/bin:/usr/bin',
+    path => '/bin:/usr/bin:/usr/sbin',
   }
 
 	# for full functionality we need this packages:


### PR DESCRIPTION
I received this error prior to this change

```
Parameter onlyif failed: 'test -f /etc/apache2/sites-enabled/000-default' is not qualified and no path was specified. Please qualify the command or specify a path.
```

This pull request simply adds the following to manifests with exec types:

```
Exec {
  path => '/bin:/usr/bin:/usr/sbin',
}
```
