### PR TITLE
Handle Python update(2.6 -> 2.7)

### DIFF
--- a/manifests/install/debian.pp
+++ b/manifests/install/debian.pp
@@ -59,19 +59,5 @@ class graphite::install::debian {
 			refreshonly => true,
 			require => [Exec["Download and untar $whisperVersion"],Anchor["graphitepkg::end"]];
 	}
-
-	# initialize database
-
-	# Because the django isntall of debian sucks we have to 
-	# create our own symlinks to python lib dir.
-	# you find your lib dir wiht: 
-	#   python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()";
-	file {
-		"/usr/lib/python2.6/dist-packages/django":
-			ensure => link,
-			target => "/usr/lib/pymodules/python2.6/django",
-			require => Anchor["graphitepkg::end"];
-	}
-	
 }
 


### PR DESCRIPTION
Removed symlink for django as python2.7 puts django in correct location.  (tested on Ubuntu Precise)
