### PR TITLE
Allow apache to be moved off default 80/443

### DIFF
--- a/README
+++ b/README
@@ -4,25 +4,25 @@ This module installs and makes basic configs for graphite, with carbon and whisp
 
 # Tested on
 RHEL/CentOS/Scientific 6+
-Debian 6+  
-Ubunutu 10.04 and newer  
+Debian 6+
+Ubunutu 10.04 and newer
 
 # Requirements:
 
-Configure conf files as you need: 
+Configure conf files as you need:
 
-templates/opt/graphite/conf/storage-schemas.conf.erb  
-templates/opt/graphite/webapp/graphite/local_settings.py.erb  
+templates/opt/graphite/conf/storage-schemas.conf.erb
+templates/opt/graphite/webapp/graphite/local_settings.py.erb
 
-### Modules needed:  
+### Modules needed:
 
-stdlib by puppetlabs  
+stdlib by puppetlabs
 
-### Software versions needed:  
-facter > 1.6.2  
-puppet > 2.6.2  
+### Software versions needed:
+facter > 1.6.2
+puppet > 2.6.2
 
-On Redhat distributions you need the EPEL or RPMforge repository, because Graphite needs packages, which are not part of the default repos.  
+On Redhat distributions you need the EPEL or RPMforge repository, because Graphite needs packages, which are not part of the default repos.
 
 # Sample usage:
 
@@ -43,6 +43,29 @@ node "graphite.my.domain" {
 	}
 }
 
+## Optional
+
+### Move Apache to alternative ports:
+
+The default puppet set up won't work if you have an existing web server in
+place. In my case this was Nginx. For me moving apache off to another port was
+good enough. To allow this you do
+
+  # Move apache to alternate HTTP/HTTPS ports:
+node "graphite.my.domain" {
+    class {'graphite':
+        gr_apache_port => 2080,
+        gr_apache_port_https => 2443,
+    }
+}
+
+
 # Author
 
 written by Daniel Werdermann dwerdermann@web.de
+
+
+# Contributers
+
+ * Oisin Mulvihill, oisin dot mulvihill at gmail dot com.
+

--- a/README.md
+++ b/README.md
@@ -3,26 +3,26 @@
 This module installs and makes basic configs for graphite, with carbon and whisper.
 
 # Tested on
-RHEL/CentOS/Scientific 6+  
-Debian 6+  
+RHEL/CentOS/Scientific 6+
+Debian 6+
 Ubunutu 10.04 and newer
 
 # Requirements
 
-Configure conf files as you need: 
+Configure conf files as you need:
 
-templates/opt/graphite/conf/storage-schemas.conf.erb  
-templates/opt/graphite/webapp/graphite/local_settings.py.erb  
+templates/opt/graphite/conf/storage-schemas.conf.erb
+templates/opt/graphite/webapp/graphite/local_settings.py.erb
 
-### Modules needed:  
+### Modules needed:
 
-stdlib by puppetlabs  
+stdlib by puppetlabs
 
-### Software versions needed:  
-facter > 1.6.2  
-puppet > 2.6.2  
+### Software versions needed:
+facter > 1.6.2
+puppet > 2.6.2
 
-On Redhat distributions you need the EPEL or RPMforge repository, because Graphite needs packages, which are not part of the default repos.  
+On Redhat distributions you need the EPEL or RPMforge repository, because Graphite needs packages, which are not part of the default repos.
 
 # Parameters
 
@@ -75,6 +75,12 @@ For further information take a look at the file templates/opt/graphite/conf/carb
   <tr>
     <td>gr_cache_query_port</td><td>7002</td><td>Self explaining.</td>
   </tr>
+  <tr>
+    <td>gr_apache_port</td><td>80</td><td>The HTTP port apache will use.</td>
+  </tr>
+  <tr>
+    <td>gr_apache_port_https</td><td>443</td><td>The HTTPS port apache will use.</td>
+  </tr>
 </table>
 
 # Sample usage:
@@ -100,7 +106,31 @@ node "graphite.my.domain" {
 }
 </pre>
 
+## Optional
+
+### Move Apache to alternative ports:
+
+The default puppet set up won't work if you have an existing web server in
+place. In my case this was Nginx. For me moving apache off to another port was
+good enough. To allow this you do
+
+<pre>
+
+  # Move apache to alternate HTTP/HTTPS ports:
+node "graphite.my.domain" {
+    class {'graphite':
+        gr_apache_port => 2080,
+        gr_apache_port_https => 2443,
+    }
+}
+
+</pre>
+
+
 # Author
 
 written by Daniel Werdermann dwerdermann@web.de
 
+# Contributers
+
+ * Oisin Mulvihill, oisin dot mulvihill at gmail dot com.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,13 @@
 #   Timezone for graphite to be used.
 #   Default is GMT.
 #
+# [*gr_apache_port*]
+#   The port to run apache on if you have an existing web server on the default
+#   port 80.
+#   Default is 80.
+#
+
+
 # === Examples
 #
 # class {'graphite':
@@ -73,7 +80,9 @@ class graphite (
 	$gr_use_insecure_unpickler    = False,
 	$gr_cache_query_interface     = '0.0.0.0',
 	$gr_cache_query_port          = 7002,
-	$gr_timezone                  = 'GMT'
+	$gr_timezone                  = 'GMT',
+	$gr_apache_port               = 80,
+	$gr_apache_port_https         = 443
 ) {
 
 	class { 'graphite::install': notify => Class['graphite::config'] }
@@ -94,6 +103,8 @@ class graphite (
 		gr_cache_query_interface     => $gr_cache_query_interface,
 		gr_cache_query_port          => $gr_cache_query_port,
 		gr_timezone                  => $gr_timezone,
+		gr_apache_port               => $gr_apache_port,
+		gr_apache_port_https         => $gr_apache_port_https,
 		require => Class['graphite::install']
 	}
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,9 +49,14 @@ class graphite::params {
 		redhat => '/etc/httpd/conf.d',
 	}
 
+	$apache_dir = $::osfamily ? {
+		debian => '/etc/apache2',
+		redhat => '/etc/httpd',
+	}
+
 	$graphitepkgs = $::osfamily ? {
 		debian => ["python-cairo","python-twisted","python-django","python-django-tagging","python-ldap","python-memcache","python-sqlite","python-simplejson"],
 		redhat => ["pycairo", "Django", "python-ldap", "python-memcached", "python-sqlite2",  "bitmap", "bitmap-fonts-compat", "python-devel", "python-crypto", "pyOpenSSL", "gcc", "python-zope-filesystem", "python-zope-interface", "git", "gcc-c++", "zlib-static", "MySQL-python"],
 	}
- 
+
 }

--- a/templates/etc/apache2/ports.conf.erb
+++ b/templates/etc/apache2/ports.conf.erb
@@ -1,0 +1,22 @@
+# If you just change the port or add more ports here, you will likely also
+# have to change the VirtualHost statement in
+# /etc/apache2/sites-enabled/000-default
+# This is also true if you have upgraded from before 2.2.9-3 (i.e. from
+# Debian etch). See /usr/share/doc/apache2.2-common/NEWS.Debian.gz and
+# README.Debian.gz
+
+NameVirtualHost *:<%= gr_apache_port %>
+Listen <%= gr_apache_port %>
+
+<IfModule mod_ssl.c>
+    # If you add NameVirtualHost *:443 here, you will also have to change
+    # the VirtualHost statement in /etc/apache2/sites-available/default-ssl
+    # to <VirtualHost *:443>
+    # Server Name Indication for SSL named virtual hosts is currently not
+    # supported by MSIE on Windows XP.
+    Listen <%= gr_apache_port_https %>
+</IfModule>
+
+<IfModule mod_gnutls.c>
+    Listen <%= gr_apache_port_https %>
+</IfModule>

--- a/templates/etc/apache2/sites-available/graphite.conf.erb
+++ b/templates/etc/apache2/sites-available/graphite.conf.erb
@@ -1,11 +1,11 @@
-<VirtualHost *:80>
+<VirtualHost *:<%= gr_apache_port %>>
 	ServerName <%= fqdn %>
-	DocumentRoot "/opt/graphite/webapp"        
+	DocumentRoot "/opt/graphite/webapp"
 
-	ErrorLog /opt/graphite/storage/error.log        
-	CustomLog /opt/graphite/storage/access.log common        
+	ErrorLog /opt/graphite/storage/error.log
+	CustomLog /opt/graphite/storage/access.log common
 
-	<Location "/">                
+	<Location "/">
 		SetHandler python-program
 		PythonPath "['/opt/graphite/webapp'] + sys.path"
 		PythonHandler django.core.handlers.modpython
@@ -24,5 +24,5 @@
 		SetHandler None
 	</Location>
 
-	
+
 </VirtualHost>


### PR DESCRIPTION
Hi @echocat,

I really like the work you've done to get graphite up and running on Ubuntu. There was only one slight draw back in my case. I want to use monitoring on a system configured to use Nginx. My solution to this is to optionally allow Apache to use alternative HTTP/HTTPS ports. Is this something you'd be interested in the main project? 

I was wondering if should allow Nginx to be used as an alternative to Apache, but this is proved more work then I can do right now.

All the best,

@oisinmulvihill
