### PR TITLE
Add support for specifying a storage dir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,6 +8,8 @@
 #
 class graphite::config inherits graphite::params {
 
+	include graphite
+
 	anchor { 'graphite::config::begin': }
 	anchor { 'graphite::config::end': }
 
@@ -46,7 +48,7 @@ class graphite::config inherits graphite::params {
 	# change access permissions for web server
 
 	exec { 'Chown graphite for web user':
-		command     => "chown -R ${::graphite::params::web_user}:${::graphite::params::web_user} /opt/graphite/storage/",
+		command     => "mkdir -p ${graphite::gr_storage_dir}/log/webapp && chown -R ${::graphite::params::web_user}:${::graphite::params::web_user} ${graphite::gr_storage_dir}",
 		cwd         => '/opt/graphite/',
 		refreshonly => true,
 		require     => [

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,9 @@
 #   If set, Nginx will be configured to use HTTP Basic authentication with the
 #   given user & password.
 #   Default is undefined
+# [*gr_storage_dir*]
+#   Use the given directory to store data.
+#   Default is '/opt/graphite/storage'
 
 
 # === Examples
@@ -114,6 +117,7 @@ class graphite (
       retentions => '1s:30m,1m:1d,5m:2y'
     }
   ],
+  $gr_storage_dir               = '/opt/graphite/storage',
   $gr_web_server                = 'apache',
   $gr_apache_port               = 80,
   $gr_apache_port_https         = 443,
@@ -127,6 +131,7 @@ class graphite (
   $secret_key                   = 'UNSAFE_DEFAULT',
   $nginx_htpassword             = undef,
 ) {
+	$gr_local_data_dir            = "${gr_storage_dir}/whisper"
 
 	class { 'graphite::install': notify => Class['graphite::config'], }
 

--- a/templates/opt/graphite/conf/carbon.conf.erb
+++ b/templates/opt/graphite/conf/carbon.conf.erb
@@ -35,6 +35,9 @@
 # Enable daily log rotation. If disabled, a kill -HUP can be used after a manual rotate
 ENABLE_LOGROTATION = True
 
+STORAGE_DIR = <%= scope.lookupvar('graphite::gr_storage_dir') %>
+LOCAL_DATA_DIR = <%= scope.lookupvar('graphite::gr_local_data_dir') %>
+
 # Specify the user to drop privileges to
 # If this is blank carbon runs as the user that invokes it
 # This user must have write access to the local data directory

--- a/templates/opt/graphite/webapp/graphite/local_settings.py.erb
+++ b/templates/opt/graphite/webapp/graphite/local_settings.py.erb
@@ -58,6 +58,7 @@ TIME_ZONE = '<%= scope.lookupvar('graphite::gr_timezone') %>'
 # of these is relative to GRAPHITE_ROOT
 #CONF_DIR = '/opt/graphite/conf'
 #STORAGE_DIR = '/opt/graphite/storage'
+STORAGE_DIR = '<%= scope.lookupvar('graphite::gr_storage_dir') %>'
 #CONTENT_DIR = '/opt/graphite/webapp/content'
 
 # To further or fully customize the paths, modify the following. Note that the


### PR DESCRIPTION
This change adds support for specifying a different storage dir for graphite. The only ugly wrinkle is that since the webapp wants to store its logs in the storage dir I had to change the Chown command to make sure that the permissions match up.
