### PR TITLE
Changing WSGISocketPrefix to /var/run/apache2/wsgi

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,6 +34,11 @@ class graphite::params {
     redhat => 'mod_wsgi',
   }
 
+  $apache_wsgi_socket_prefix = $::osfamily ? {
+    debian => '/var/run/apache2/wsgi',
+    redhat => 'run/wsgi',
+  }
+
   $apache_service_name = $::osfamily ? {
     debian => 'apache2',
     redhat => 'httpd',

--- a/templates/etc/apache2/sites-available/graphite.conf.erb
+++ b/templates/etc/apache2/sites-available/graphite.conf.erb
@@ -10,7 +10,7 @@
 
 # XXX You need to set this up!
 # Read http://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGISocketPrefix
-WSGISocketPrefix /var/run/apache2/wsgi
+WSGISocketPrefix <%= scope.lookupvar('graphite::apache_wsgi_socket_prefix') %>
 
 <VirtualHost *:<%= scope.lookupvar('graphite::gr_apache_port') %>>
 	ServerName <%= fqdn %>


### PR DESCRIPTION
Tried to use the puppet-graphite module and got the following error:

[Mon Sep 30 15:04:27 2013] [error] [client 10.10.10.1](2)No such file or directory: mod_wsgi (pid=6229): Unable to connect to WSGI daemon process 'graphite' on '/etc/apache2/run/wsgi.6226.0.1.sock' after multiple attempts.

Found this blog post http://marcelo-olivas.blogspot.be/2012/06/installing-graphite-on-ubuntu-1204.html

Apparently it seems to solve the issue.
