### PR TITLE
Wrong variable: addressed graphite::apache_wsgi_socket_prefix, should be graphite::params::apache_wsgi_socket_prefix

### DIFF
--- a/templates/etc/apache2/sites-available/graphite.conf.erb
+++ b/templates/etc/apache2/sites-available/graphite.conf.erb
@@ -10,7 +10,7 @@
 
 # XXX You need to set this up!
 # Read http://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGISocketPrefix
-WSGISocketPrefix <%= scope.lookupvar('graphite::apache_wsgi_socket_prefix') %>
+WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefix') %>
 
 <VirtualHost *:<%= scope.lookupvar('graphite::gr_apache_port') %>>
 	ServerName <%= fqdn %>


### PR DESCRIPTION
Yesterday I made the wrong assumption: the graphite.conf Apache vhost template contains "graphite::apache_wsgi_socket_prefix", but it should be "graphite::params::apache_wsgi_socket_prefix".

My bad!
Thijs
