### PR TITLE
Variable fqdn with @

### DIFF
--- a/templates/etc/apache2/sites-available/graphite.conf.erb
+++ b/templates/etc/apache2/sites-available/graphite.conf.erb
@@ -13,7 +13,7 @@
 WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefix') %>
 
 <VirtualHost *:<%= scope.lookupvar('graphite::gr_apache_port') %>>
-	ServerName <%= fqdn %>
+	ServerName <%= @fqdn %>
 	DocumentRoot "/opt/graphite/webapp"
 
 	ErrorLog /opt/graphite/storage/error.log


### PR DESCRIPTION
Warning: Variable access via 'fqdn' is deprecated. Use '@fqdn' instead. template[/tmp/vagrant-puppet-1/modules-0/graphite/templates/etc/apache2/sites-available/graphite.conf.erb]:16
