### PR TITLE
enable mod_headers on debian

### DIFF
--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -28,6 +28,10 @@ class graphite::config_apache inherits graphite::params {
 
   case $::osfamily {
     debian: {
+      exec { 'enable mod_headers':
+        command => 'a2enmod headers',
+        require => Package["${::graphite::params::apache_wsgi_pkg}"]
+      }
       exec { 'Disable default apache site':
         command => 'a2dissite default',
         onlyif  => 'test -f /etc/apache2/sites-enabled/000-default',


### PR DESCRIPTION
mod_headers isn't enabled by default when installing apache2 on ubuntu
