### PR TITLE
Fix for Apache 2.4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,6 +83,8 @@
 #   The port to run web server on if you have an existing web server on the default
 #   port 80.
 #   Default is 80.
+# [*gr_apache_24*]
+#   Set to true if you are using Apache 2.4 or later
 # [*gr_django_1_4_or_less*]
 #   Set to true to use old Django settings style.
 #   Default is false.
@@ -258,6 +260,7 @@ class graphite (
   $gr_web_cors_allow_from_all   = false,
   $gr_apache_port               = 80,
   $gr_apache_port_https         = 443,
+  $gr_apache_24        		= false,
   $gr_django_1_4_or_less        = false,
   $gr_django_db_engine          = 'django.db.backends.sqlite3',
   $gr_django_db_name            = '/opt/graphite/storage/graphite.db',
@@ -314,16 +317,16 @@ class graphite (
   $gr_cluster_find_timeout      = 2.5,
   $gr_cluster_retry_delay       = 60,
   $gr_cluster_cache_duration    = 300,
-  $nginx_htpasswd               = undef,
+  $nginx_htpassword             = undef,
 ) {
 
-  class { 'graphite::install': notify => Class['graphite::config'], }
+	class { 'graphite::install': notify => Class['graphite::config'], }
 
-  class { 'graphite::config':  require => Class['graphite::install'], }
+	class { 'graphite::config':	require => Class['graphite::install'], }
 
-  # Allow the end user to establish relationships to the "main" class
-  # and preserve the relationship to the implementation classes through
-  # a transitive relationship to the composite class.
-  anchor { 'graphite::begin': before => Class['graphite::install'] }
-  anchor { 'graphite::end':  require => Class['graphite::config'] }
+	# Allow the end user to establish relationships to the "main" class
+	# and preserve the relationship to the implementation classes through
+	# a transitive relationship to the composite class.
+	anchor { 'graphite::begin': before => Class['graphite::install'] }
+	anchor { 'graphite::end':  require => Class['graphite::config'] }
 }

--- a/templates/etc/apache2/sites-available/graphite.conf.erb
+++ b/templates/etc/apache2/sites-available/graphite.conf.erb
@@ -33,6 +33,11 @@ WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefi
 	Alias /content/ /opt/graphite/webapp/content/
 	<Location "/content/">
 			SetHandler None
+<% if scope.lookupvar('graphite::gr_apache_24') %>
+                        Options All
+                        AllowOverride All
+                        Require all granted
+<% end %>
 	</Location>
 
 	# XXX In order for the django admin site media to work you
@@ -42,13 +47,25 @@ WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefi
 	Alias /media/ "@DJANGO_ROOT@/contrib/admin/media/"
 	<Location "/media/">
 			SetHandler None
+<% if scope.lookupvar('graphite::gr_apache_24') %>
+                        Options All
+                        AllowOverride All
+                        Require all granted
+<% end %>
 	</Location>
 
 	# The graphite.wsgi file has to be accessible by apache. It won't
 	# be visible to clients because of the DocumentRoot though.
 	<Directory /opt/graphite/conf/>
+<% if scope.lookupvar('graphite::gr_apache_24') %>
+                        Options All
+                        AllowOverride All
+                        Require all granted
+<% else %>
+
 			Order deny,allow
 			Allow from all
+<% end %>
 	</Directory>
 	
 <% if scope.lookupvar('graphite::gr_web_cors_allow_from_all') %>


### PR DESCRIPTION
I added a new gr_apache_24 boolean. If set, modifies a few <Directory> configuration directives in the Apache vhost configuration, so that the Graphite web application works uner Apache 2.4. This is needed, as newer distributions ship Apache > 2.2 (e.g. Ubuntu 13.10), and don't work out of the box.
