### PR TITLE
Removes requirement for python-txamqp on Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,7 +70,7 @@ class graphite::params {
   }
 
   $graphitepkgs = $::osfamily ? {
-    debian => ["python-cairo","python-twisted","python-django","python-django-tagging","python-ldap","python-memcache","python-sqlite","python-simplejson","python-txamqp"],
+    debian => ["python-cairo","python-twisted","python-django","python-django-tagging","python-ldap","python-memcache","python-sqlite","python-simplejson"],
     redhat => ["pycairo", "Django14", "python-ldap", "python-memcached", "python-sqlite2",  "bitmap", "bitmap-fonts-compat", "python-devel", "python-crypto", "pyOpenSSL", "gcc", "python-zope-filesystem", "python-zope-interface", "git", "gcc-c++", "zlib-static", "MySQL-python","python-txamqp"],
   }
 


### PR DESCRIPTION
The package is unavailable for more recent versions of Debian, so it’s hard-removed here.

There may be a more elegant way of doing this.
