### PR TITLE
Parameterize the install of ca-certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ For further information take a look at the file templates/opt/graphite/conf/carb
   <tr>
     <td>nginx_htpasswd</td><td>undef</td><td>The user and salted SHA-1 (SSHA) password for Nginx authentication. If set, Nginx will be configured to use HTTP Basic authentication with the given user & password.</td>
   </tr>
+  <tr>
+    <td>manage_ca_certificate</td><td>true</td><td>Used to determine if the module should install ca-certificate on deiban machines during the initial installation.</td>
+  </tr>
 </table>
 
 # Sample usage:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -208,6 +208,8 @@
 #   If set, Nginx will be configured to use HTTP Basic authentication with the
 #   given user & password.
 #   Default is undefined
+# [*manage_ca_certificate*]
+#   Used to determine to install ca-certificate or not. default = true
 
 
 # === Examples
@@ -315,6 +317,7 @@ class graphite (
   $gr_cluster_retry_delay       = 60,
   $gr_cluster_cache_duration    = 300,
   $nginx_htpasswd               = undef,
+  $manage_ca_certificate        = true,
 ) {
 
   class { 'graphite::install': notify => Class['graphite::config'], }

--- a/manifests/install/debian.pp
+++ b/manifests/install/debian.pp
@@ -27,9 +27,11 @@ class graphite::install::debian {
 
   # Download graphite sources
 
-  package { 'ca-certificates':
-    # needed to download from httpS://github.com/
-    ensure => installed,
+  if $::graphite::manage_ca_certificate {
+    package { 'ca-certificates':
+      # needed to download from httpS://github.com/
+      ensure => installed,
+    }
   }
   exec {
     "Download and untar webapp ${::graphite::params::graphiteVersion}":


### PR DESCRIPTION
If ca-certificate is declared in any other puppet resource, you get errors trying to use this module.  This allows for external management of ca-certificate.
