### PR TITLE
Add ldap parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,24 @@ For further information take a look at the file templates/opt/graphite/conf/carb
   <tr>
     <td>manage_ca_certificate</td><td>true</td><td>Used to determine if the module should install ca-certificate on debian machines during the initial installation.</td>
   </tr>
+    <tr>
+    <td>gr_use_ldap</td><td>false</td><td>Turn ldap authentication on/off.</td>
+  </tr>
+    <tr>
+    <td>gr_ldap_uri</td><td>''</td><td>Set ldap uri.</td>
+  </tr>
+    <tr>
+    <td>gr_ldap_search_base</td><td>''</td><td>Set the ldap search base.</td>
+  </tr>
+    <tr>
+    <td>gr_ldap_base_user</td><td>''</td><td>Set ldap base user.</td>
+  </tr>
+    <tr>
+    <td>gr_ldap_base_pass</td><td>''</td><td>Set ldap password.</td>
+  </tr>
+    <tr>
+    <td>gr_ldap_user_query</td><td>(username=%s)</td><td>Set ldap user query.</td>
+  </tr>
 </table>
 
 # Sample usage:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -210,7 +210,18 @@
 #   Default is undefined
 # [*manage_ca_certificate*]
 #   Used to determine to install ca-certificate or not. default = true
-
+# [*gr_use_ldap*]
+#   Turn ldap authentication on/off. Default = false
+# [*gr_ldap_uri*]
+#   Set ldap uri.  Default = ''
+# [*gr_ldap_search_base*]
+#   Set the ldap search base.  Default = ''
+# [*gr_ldap_base_user*]
+#   Set ldap base user.  Default = ''
+# [*gr_ldap_base_pass*]
+#   Set ldap password.  Default = ''
+# [*gr_ldap_user_query*]
+#   Set ldap user query.  Default = '(username=%s)'
 
 # === Examples
 #
@@ -318,6 +329,12 @@ class graphite (
   $gr_cluster_cache_duration    = 300,
   $nginx_htpasswd               = undef,
   $manage_ca_certificate        = true,
+  $gr_use_ldap                  = false,
+  $gr_ldap_uri                  = '',
+  $gr_ldap_search_base          = '',
+  $gr_ldap_base_user            = '',
+  $gr_ldap_base_pass            = '',
+  $gr_ldap_user_query           = '(username=%s)',
 ) {
 
   class { 'graphite::install': notify => Class['graphite::config'], }

--- a/templates/opt/graphite/webapp/graphite/local_settings.py.erb
+++ b/templates/opt/graphite/webapp/graphite/local_settings.py.erb
@@ -98,6 +98,14 @@ MEMCACHE_HOSTS = <%= scope.lookupvar('graphite::gr_memcache_hosts') %>
 #####################################
 # Authentication Configuration #
 #####################################
+<% if scope.lookupvar('graphite::gr_use_ldap') %>
+USE_LDAP_AUTH = True
+LDAP_URI = "<%= scope.lookupvar('graphite::gr_ldap_uri') %>"
+LDAP_SEARCH_BASE = "<%= scope.lookupvar('graphite::gr_ldap_search_base') %>"
+LDAP_BASE_USER = "<%= scope.lookupvar('graphite::gr_ldap_base_user') %>"
+LDAP_BASE_PASS = "<%= scope.lookupvar('graphite::gr_ldap_base_pass') %>"
+LDAP_USER_QUERY = "<%= scope.lookupvar('graphite::gr_ldap_user_query') %>"
+<% else %>
 ## LDAP / ActiveDirectory authentication setup
 #USE_LDAP_AUTH = True
 #LDAP_SERVER = "ldap.mycompany.com"
@@ -108,6 +116,7 @@ MEMCACHE_HOSTS = <%= scope.lookupvar('graphite::gr_memcache_hosts') %>
 #LDAP_BASE_USER = "CN=some_readonly_account,DC=mycompany,DC=com"
 #LDAP_BASE_PASS = "readonly_account_password"
 #LDAP_USER_QUERY = "(username=%s)"  #For Active Directory use "(sAMAccountName=%s)"
+<% end %>
 #
 # If you want to further customize the ldap connection options you should
 # directly use ldap.set_option to set the ldap module's global options.


### PR DESCRIPTION
This adds the ability to use/manage the ldap section of local_settings.py to allow for logging into the graphite ui.
