### PR TITLE
Remove trailing commas in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,19 +1,19 @@
 {
   "operatingsystem_support": [
       {
-        "operatingsystem": "RedHat",
+        "operatingsystem": "RedHat"
       },
       {
-        "operatingsystem": "CentOS",
+        "operatingsystem": "CentOS"
       },
       {
-        "operatingsystem": "Scientific",
+        "operatingsystem": "Scientific"
       },
       {
-        "operatingsystem": "Debian",
+        "operatingsystem": "Debian"
       },
       {
-        "operatingsystem": "Ubuntu",
+        "operatingsystem": "Ubuntu"
       }
   ],
   "name": "dwerder-graphite",


### PR DESCRIPTION
The commas after operatingsystem compatiblity expressions created
invalid JSON that could not be properly built into a release tarball.
This commit removes each. A future commit could remove all but
operatingsystem_support from the root metadata.json and the result
of puppet module build would still produce the right metadata.
