### PR TITLE
Puppet attempted to install pip managed packages multiple times

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -45,9 +45,11 @@ class graphite::install(
     ensure   => $django_tagging_ver,
   }->
   package{'twisted':
+    name     => 'Twisted',
     ensure   => $twisted_ver,
   }->
   package{'txamqp':
+    name     => 'txAMQP',
     ensure   => $txamqp_ver,
   }->
   package{'graphite-web':


### PR DESCRIPTION
The pip provider is case sensitive. The packages twisted and txamqp are
listed in pip as Twisted and txAMQP. If these packages are not listed
exactly as displayed in pip puppet will reinstall them which produces
output like this

Notice: /Stage[main]/Graphite::Install/Package[twisted]/ensure: created
Notice: /Stage[main]/Graphite::Install/Package[txamqp]/ensure: created
Notice: /Stage[main]/Graphite::Config/Exec[Initial django db creation]: Triggered 'refresh' from 2 events
Notice: /Stage[main]/Graphite::Config/Service[carbon-cache]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Graphite::Config/Exec[Chown graphite for web user]: Triggered 'refresh' from 2 events

on every puppet run.
