### PR TITLE
make nginx proxy_read_timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,10 @@ Default is 'UNSAFE_DEFAULT' (string). CHANGE IT! Secret used as salt for things 
 
 Default is undef (string). The user and salted SHA-1 (SSHA) password for Nginx authentication. If set, Nginx will be configured to use HTTP Basic authentication with the given user & password. e.g.: 'testuser:$jsfak3.c3Fd0i1k2kel/3sdf3'
 
+#####`nginx_proxy_read_timeout`
+
+Default is 10. Value to use for nginx's proxy_read_timeout setting
+
 #####`manage_ca_certificate`
 
 Default is true (boolean). Used to determine if the module should install ca-certificate on Debian machines during the initial installation.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -247,6 +247,9 @@
 #   If set, Nginx will be configured to use HTTP Basic authentication with the
 #   given user & password.
 #   Default is undefined
+# [*nginx_proxy_read_timeout*]
+#   Value to use for nginx's proxy_read_timeout setting
+#   Default is 10s
 # [*manage_ca_certificate*]
 #   Used to determine to install ca-certificate or not. default = true
 # [*gr_use_ldap*]
@@ -399,6 +402,7 @@ class graphite (
   $gr_cluster_retry_delay       = 60,
   $gr_cluster_cache_duration    = 300,
   $nginx_htpasswd               = undef,
+  $nginx_proxy_read_timeout     = 10,
   $manage_ca_certificate        = true,
   $gr_use_ldap                  = false,
   $gr_ldap_uri                  = '',

--- a/templates/etc/nginx/sites-available/graphite.erb
+++ b/templates/etc/nginx/sites-available/graphite.erb
@@ -31,7 +31,7 @@ server {
 		proxy_redirect off;
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_connect_timeout 10;
-		proxy_read_timeout 10;
+		proxy_read_timeout <%= scope.lookupvar('graphite::nginx_proxy_read_timeout') %>;
 
 		proxy_pass http://unix:/var/run/graphite.sock:/;
 


### PR DESCRIPTION
10s is a reasonable default but some may find graphite without enough IO
and thus performing slowly and in need a fix in the short term.
