### PR TITLE
allow setting gunicorn's timeout parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,10 @@ combined with the option `gr_web_server` = 'wsgionly' and http://forge.puppetlab
 with some custom vhosts.
 The sample external auth app is available from [here](https://github.com/antoinerg/nginx_auth_backend)
 
+#####`gunicorn_arg_timeout`
+
+Default is 30.  value to pass to gunicorns --timeout arg.
+
 ##Requirements
 
 ###Modules needed:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -269,6 +269,9 @@
 #   variable (mainly for nginx use) to tell Graphite a user is authenticated.
 #   Useful when using an external auth handler with X-Accel-Redirect etc.
 #   Example value - HTTP_X_REMOTE_USER
+# [*gunicorn_arg_timeout*]
+#   value to pass to gunicorns --timeout arg.
+#   Default is 30
 
 # === Examples
 #
@@ -408,7 +411,8 @@ class graphite (
   $gr_ldap_user_query           = '(username=%s)',
   $gr_use_remote_user_auth      = 'False',
   $gr_remote_user_header_name   = undef,
-  $gr_local_data_dir            = '/opt/graphite/storage/whisper'
+  $gr_local_data_dir            = '/opt/graphite/storage/whisper',
+  $gunicorn_arg_timeout         = 30
 ) {
   # Validation of input variables.
   # TODO - validate all the things

--- a/templates/etc/gunicorn.d/graphite.erb
+++ b/templates/etc/gunicorn.d/graphite.erb
@@ -4,6 +4,7 @@ CONFIG = {
     'user': 'www-data',
     'group': 'www-data',
     'args': (
+	'--timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %>',
         '--bind=unix:/var/run/graphite.sock',
         '--workers=2',
     ),


### PR DESCRIPTION
might be useful for those experiencing slow response times from graphite
(say due to IO) who want to allow a little more time to respond.   (while trying to fix IO) 
