### PR TITLE
allow setting gunicorn's --worker arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,10 @@ The sample external auth app is available from [here](https://github.com/antoine
 
 Default is 30.  value to pass to gunicorns --timeout arg.
 
+#####`gunicorn_workers`
+  
+Default is 2. value to pass to gunicorn's --worker arg.
+
 ##Requirements
 
 ###Modules needed:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -300,8 +300,11 @@
 #   Useful when using an external auth handler with X-Accel-Redirect etc.
 #   Example value - HTTP_X_REMOTE_USER
 # [*gunicorn_arg_timeout*]
-#   value to pass to gunicorns --timeout arg.
+#   value to pass to gunicorn's --timeout arg.
 #   Default is 30
+# [*gunicorn_workers*]
+#   value to pass to gunicorn's --worker arg.
+#   Default is 2
 
 # === Examples
 #
@@ -451,7 +454,8 @@ class graphite (
   $gr_use_remote_user_auth      = 'False',
   $gr_remote_user_header_name   = undef,
   $gr_local_data_dir            = '/opt/graphite/storage/whisper',
-  $gunicorn_arg_timeout         = 30
+  $gunicorn_arg_timeout         = 30,
+  $gunicorn_workers             = 2,
 ) {
   # Validation of input variables.
   # TODO - validate all the things

--- a/templates/etc/gunicorn.d/graphite.erb
+++ b/templates/etc/gunicorn.d/graphite.erb
@@ -6,6 +6,6 @@ CONFIG = {
     'args': (
 	'--timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %>',
         '--bind=unix:/var/run/graphite.sock',
-        '--workers=2',
+	'--workers=<%= scope.lookupvar('graphite::gunicorn_workers') %>',
     ),
 }


### PR DESCRIPTION
allows you to set the --worker argument.     

I would suggest the default actually be changed from 2,  but this is a least change PR. 

The problem is when using gunicorn sync worker type,  the default,   they can only handle one outstanding request at a time,  however in a cluster graphite-web makes blocking calls itself to other graphite webs  so it's possible to get the right set of queries that cause all workers across your cluster to be blocked on  responses from the other graphite-web server which are in turn not servicing their queue from nginx because they are blocked. 

A better change would be to support one of the asynchronous worker-types by default.   but  I didn't have time to make that change and show it works.  

on our 5 node graphite cluster of 2 core nodes we set our worker count to 8. 
