### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This module installs and makes basic configs for graphite, with carbon and whisp
 
 ##Module Description
 
-[Graphite](http://graphite.readthedocs.org/en/latest/overview.html), and its components Carbon and Whispter, is an enterprise-scale monitoring tool. This module sets up a simple graphite server with all its components. Furthermore it can be used to set up more complex graphite environments with metric aggregation, clustering and so on.
+[Graphite](http://graphite.readthedocs.org/en/latest/overview.html), and its components Carbon and Whisper, is an enterprise-scale monitoring tool. This module sets up a simple graphite server with all its components. Furthermore it can be used to set up more complex graphite environments with metric aggregation, clustering and so on.
 
 ##Setup
 


### PR DESCRIPTION
Prior to this commit, the Module Description section had `Whisper` spelled incorrectly. This commit fixes that spelling.
