### PR TITLE
Add LOG_CACHE_PERFORMANCE to local_settings.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,15 @@ Default is false. Set lock writes for whisper
 
 Default is false. Set fallocate_create for whisper
 
+#####'gr_log_cache_performance'
+Default is false. Logs timings for remote calls to carbon-cache
+
+#####'gr_log_rendering_performance'
+Default is false. Triggers the creation of rendering.log which logs timings for calls to the The Render URL API
+
+#####'gr_log_metric_access'
+Default is false. Trigges the creation of metricaccess.log which logs access to Whisper and RRD data files
+
 ##Requirements
 
 ###Modules needed:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -339,7 +339,21 @@
 # [*gr_whisper_fallocate_create*]
 #   Set fallocate_create for whisper
 #   Default is false
-
+#
+# [*gr_log_cache_performance*]
+#   logs timings for remote calls to carbon-cache
+#   Default is false
+#
+# [*gr_log_rendering_performance*]
+#   Triggers the creation of rendering.log which logs timings for calls to
+#   the The Render URL API
+#   Default is false
+#
+# [*gr_log_metric_access*]
+#   Trigges the creation of metricaccess.log which logs access to Whisper
+#   and RRD data files
+#   Default is false
+#
 # === Examples
 #
 # class {'graphite':
@@ -495,7 +509,10 @@ class graphite (
   $gr_relay_instances           = [],
   $gr_aggregator_instances      = [],
   $gr_whisper_lock_writes       = 'False',
-  $gr_whisper_fallocate_create  = 'False'
+  $gr_whisper_fallocate_create  = 'False',
+  $gr_log_cache_performance     = 'False',
+  $gr_log_rendering_performance = 'False',
+  $gr_log_metric_access         = 'False',
 ) {
   # Validation of input variables.
   # TODO - validate all the things

--- a/templates/opt/graphite/webapp/graphite/local_settings.py.erb
+++ b/templates/opt/graphite/webapp/graphite/local_settings.py.erb
@@ -23,9 +23,9 @@ TIME_ZONE = '<%= scope.lookupvar('graphite::gr_timezone') %>'
 #DOCUMENTATION_URL = "http://graphite.readthedocs.org/"
 
 # Logging
-#LOG_RENDERING_PERFORMANCE = True
-#LOG_CACHE_PERFORMANCE = True
-#LOG_METRIC_ACCESS = True
+LOG_RENDERING_PERFORMANCE = <%= scope.lookupvar('graphite::gr_log_rendering_performance') %>
+LOG_CACHE_PERFORMANCE = <%= scope.lookupvar('graphite::gr_log_cache_performance') %>
+LOG_METRIC_ACCESS = <%= scope.lookupvar('graphite::gr_log_metric_access') %>
 
 # Enable full debug page display on exceptions (Internal Server Error pages)
 #DEBUG = True


### PR DESCRIPTION
This adds the parameter LOG_CACHE_PERFORMANCE to local_settings.py.  The
default in current master is False, in previous versions it has been
True.
