### PR TITLE
Fixes incompatability with gawk

### DIFF
--- a/templates/etc/init.d/carbon-aggregator.erb
+++ b/templates/etc/init.d/carbon-aggregator.erb
@@ -20,7 +20,7 @@ if [ $# -gt 1 ]; then
     shift
     INSTANCES=$@
 else
-    INSTANCES=$(awk '$1 ~ /^\[aggregator/ { sub("\[aggregator:?","", $1); sub("]$","", $1); if ($1 == "") { print "a"} else { print $1} }' "${CARBON_CONF}")
+    INSTANCES=$(awk '$1 ~ /^\[aggregator/ { sub("\\[aggregator:?","", $1); sub("]$","", $1); if ($1 == "") { print "a"} else { print $1} }' "${CARBON_CONF}")
 fi
 
 case "${OPERATION}" in

--- a/templates/etc/init.d/carbon-cache.erb
+++ b/templates/etc/init.d/carbon-cache.erb
@@ -20,7 +20,7 @@ if [ $# -gt 1 ]; then
     shift
     INSTANCES=$@
 else
-    INSTANCES=$(awk '$1 ~ /^\[cache/ { sub("\[cache:?","", $1); sub("]$","", $1); if ($1 == "") { print "a"} else { print $1} }' "${CARBON_CONF}")
+    INSTANCES=$(awk '$1 ~ /^\[cache/ { sub("\\[cache:?","", $1); sub("]$","", $1); if ($1 == "") { print "a"} else { print $1} }' "${CARBON_CONF}")
 fi
 
 case "${OPERATION}" in

--- a/templates/etc/init.d/carbon-relay.erb
+++ b/templates/etc/init.d/carbon-relay.erb
@@ -20,7 +20,7 @@ if [ $# -gt 1 ]; then
     shift
     INSTANCES=$@
 else
-    INSTANCES=$(awk '$1 ~ /^\[relay/ { sub("\[relay:?","", $1); sub("]$","", $1); if ($1 == "") { print "a"} else { print $1} }' "${CARBON_CONF}")
+    INSTANCES=$(awk '$1 ~ /^\[relay/ { sub("\\[relay:?","", $1); sub("]$","", $1); if ($1 == "") { print "a"} else { print $1} }' "${CARBON_CONF}")
 fi
 
 case "${OPERATION}" in


### PR DESCRIPTION
Need to escape the '\' as well otherwise it will fail with gawk:

service carbon-cache restart
awk: cmd. line:1: warning: escape sequence `\[' treated as plain`['
awk: cmd. line:1: (FILENAME=/opt/graphite/conf/carbon.conf FNR=3) fatal: Unmatched [ or [^: /[cache:?/
awk: cmd. line:1: warning: escape sequence `\[' treated as plain`['
awk: cmd. line:1: (FILENAME=/opt/graphite/conf/carbon.conf FNR=3) fatal: Unmatched [ or [^: /[cache:?/
awk: cmd. line:1: warning: escape sequence `\[' treated as plain`['
awk: cmd. line:1: (FILENAME=/opt/graphite/conf/carbon.conf FNR=3) fatal: Unmatched [ or [^: /[cache:?/
