### PR TITLE
Fix bug with mismatched package name

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -64,7 +64,7 @@ class graphite::install(
     },
     'Twisted'        => {
       ensure => $twisted_ver,
-      before => Python::Pip['txamqp'],
+      before => Python::Pip['txAMQP'],
     },
     'txAMQP'         => {
       ensure => $txamqp_ver,


### PR DESCRIPTION
This fixes an error I had in the Pip package listing:

```
Error 400 on SERVER: Invalid relationship: Python::Pip[Twisted] { before => Python::Pip[txamqp] }, because Python::Pip[txamqp] doesn't seem to be in the catalog
```
