### PR TITLE
Updated metadata.json to fix issue.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,7 @@
   "project_page": "https://github.com/echocat/puppet-graphite",
   "issues_url": "https://github.com/echocat/puppet-graphite/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 3.2.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0"}
   ]
 
 }


### PR DESCRIPTION
Librarian puppet does not parse puppetlabs-stdlib you need to use puppetlabs/stdlib. This goes for any dependency needs to be formatted with / instead of - .
