### PR TITLE
Fix wrong lookup path

### DIFF
--- a/templates/etc/apache2/sites-available/graphite.conf.erb
+++ b/templates/etc/apache2/sites-available/graphite.conf.erb
@@ -38,7 +38,7 @@ WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefi
 	Alias /content/ /opt/graphite/webapp/content/
 	<Location "/content/">
 			SetHandler None
-<% if scope.lookupvar('graphite::params::gr_apache_24') %>
+<% if scope.lookupvar('graphite::gr_apache_24') %>
 			Options All
 			AllowOverride All
 			Require all granted
@@ -52,7 +52,7 @@ WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefi
 	Alias /media/ "@DJANGO_ROOT@/contrib/admin/media/"
 	<Location "/media/">
 			SetHandler None
-<% if scope.lookupvar('graphite::params::gr_apache_24') %>
+<% if scope.lookupvar('graphite::gr_apache_24') %>
 			Options All
 			AllowOverride All
 			Require all granted
@@ -62,7 +62,7 @@ WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefi
 	# The graphite.wsgi file has to be accessible by apache. It won't
 	# be visible to clients because of the DocumentRoot though.
 	<Directory /opt/graphite/conf/>
-<% if scope.lookupvar('graphite::params::gr_apache_24') %>
+<% if scope.lookupvar('graphite::gr_apache_24') %>
 			Options All
 			AllowOverride All
 			Require all granted


### PR DESCRIPTION
This patch fixes the following behaviour when setting ```$gr_apache_24 = true```:

```apache
Notice: /Stage[main]/Graphite::Config_apache/File[/etc/httpd/conf.d/graphite.conf]/content:
--- /etc/httpd/conf.d/graphite.conf	2015-01-05 14:20:27.490305726 +0100
+++ /tmp/puppet-file20150105-23341-4sh6ul	2015-01-05 14:51:16.689950491 +0100
@@ -33,9 +33,6 @@
 	Alias /content/ /opt/graphite/webapp/content/
 	<Location "/content/">
 			SetHandler None
-			Options All
-			AllowOverride All
-			Require all granted

 	</Location>

@@ -46,9 +43,6 @@
 	Alias /media/ "@DJANGO_ROOT@/contrib/admin/media/"
 	<Location "/media/">
 			SetHandler None
-			Options All
-			AllowOverride All
-			Require all granted

 	</Location>

@@ -56,9 +50,6 @@
 	# be visible to clients because of the DocumentRoot though.
 	<Directory /opt/graphite/conf/>

-			Options All
-			AllowOverride All
-			Require all granted
 			Order deny,allow
 			Allow from all

```