### PR TITLE
enhance relay template to set all options

### DIFF
--- a/templates/etc/init.d/Debian/carbon-aggregator.erb
+++ b/templates/etc/init.d/Debian/carbon-aggregator.erb
@@ -15,13 +15,14 @@
 PYTHON_CMD='python -W ignore'
 CARBON_DAEMON="aggregator"
 GRAPHITE_DIR="/opt/graphite"
+STOP_COUNTER=12 # 12 times 5s -> 60 secs
 
 OPERATION="$1"
 if [ $# -gt 1 ]; then
     shift
     INSTANCES=$@
 else
-	INSTANCES=`grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2`
+    INSTANCES=`grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2`
 fi
 
 case "${OPERATION}" in
@@ -34,10 +35,11 @@ case "${OPERATION}" in
         for INSTANCE in ${INSTANCES}; do
             ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop
             sleep 3
-            while [ -f ${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
+            CNT=$STOP_COUNTER
+            while [ `/usr/bin/pgrep -cf "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}"` -eq 1 ]; do
                 echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
                 sleep 5
-                #TODO: add timer to prevend endless waiting
+                CNT=`expr ${CNT} - 1`
             done
         done
         ;;
@@ -47,16 +49,7 @@ case "${OPERATION}" in
         done
         ;;
     restart)
-        for INSTANCE in ${INSTANCES}; do
-            ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop
-            sleep 3
-            while [ -f ${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
-                echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
-                sleep 5
-                #TODO: add timer to prevend endless waiting
-            done
-            ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start
-        done
+        $0 stop $INSTANCES && sleep 2 && $0 start $INSTANCES
         ;;
     *)
         echo "Usage: $0 {start|stop|restart|status} [instance instance ...]"

--- a/templates/etc/init.d/Debian/carbon-cache.erb
+++ b/templates/etc/init.d/Debian/carbon-cache.erb
@@ -15,13 +15,14 @@
 PYTHON_CMD='python -W ignore'
 CARBON_DAEMON="cache"
 GRAPHITE_DIR="/opt/graphite"
+STOP_COUNTER=12 # 12 times 5s -> 60 secs
 
 OPERATION="$1"
 if [ $# -gt 1 ]; then
     shift
     INSTANCES=$@
 else
-	INSTANCES=`grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2`
+    INSTANCES=`grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2`
 fi
 
 case "${OPERATION}" in
@@ -34,10 +35,11 @@ case "${OPERATION}" in
         for INSTANCE in ${INSTANCES}; do
             ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop
             sleep 3
-            while [ -f ${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
+            CNT=$STOP_COUNTER
+            while [ `/usr/bin/pgrep -cf "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}"` -eq 1 ]; do
                 echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
                 sleep 5
-                #TODO: add timer to prevend endless waiting
+                CNT=`expr ${CNT} - 1`
             done
         done
         ;;
@@ -47,16 +49,7 @@ case "${OPERATION}" in
         done
         ;;
     restart)
-        for INSTANCE in ${INSTANCES}; do
-            ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop
-            sleep 3
-            while [ -f ${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
-                echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
-                sleep 5
-                #TODO: add timer to prevend endless waiting
-            done
-            ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start
-        done
+        $0 stop $INSTANCES && sleep 2 && $0 start $INSTANCES
         ;;
     *)
         echo "Usage: $0 {start|stop|restart|status} [instance instance ...]"

--- a/templates/etc/init.d/Debian/carbon-relay.erb
+++ b/templates/etc/init.d/Debian/carbon-relay.erb
@@ -15,13 +15,14 @@
 PYTHON_CMD='python -W ignore'
 CARBON_DAEMON="relay"
 GRAPHITE_DIR="/opt/graphite"
+STOP_COUNTER=12 # 12 times 5s -> 60 secs
 
 OPERATION="$1"
 if [ $# -gt 1 ]; then
     shift
     INSTANCES=$@
 else
-	INSTANCES=`grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2`
+    INSTANCES=`grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2`
 fi
 
 case "${OPERATION}" in
@@ -34,10 +35,11 @@ case "${OPERATION}" in
         for INSTANCE in ${INSTANCES}; do
             ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop
             sleep 3
-            while [ -f ${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
+            CNT=$STOP_COUNTER
+            while [ `/usr/bin/pgrep -cf "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}"` -eq 1 ]; do
                 echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
                 sleep 5
-                #TODO: add timer to prevend endless waiting
+                CNT=`expr ${CNT} - 1`
             done
         done
         ;;
@@ -47,16 +49,7 @@ case "${OPERATION}" in
         done
         ;;
     restart)
-        for INSTANCE in ${INSTANCES}; do
-            ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop
-            sleep 3
-            while [ -f ${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
-                echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
-                sleep 5
-                #TODO: add timer to prevend endless waiting
-            done
-            ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start
-        done
+        $0 stop $INSTANCES && sleep 2 && $0 start $INSTANCES
         ;;
     *)
         echo "Usage: $0 {start|stop|restart|status} [instance instance ...]"

--- a/templates/opt/graphite/conf/relay-rules.conf.erb
+++ b/templates/opt/graphite/conf/relay-rules.conf.erb
@@ -4,7 +4,10 @@
   rules = scope.lookupvar('graphite::gr_relay_rules')
   rules.sort.each do |name, rule| %>
 [<%= name %>]
-<%- if rule['default'] then %>default = true<% end %>
-<%- if rule['pattern'] then %>pattern = <%= rule['pattern'] %><% end %>
-destinations = <%= rule['destinations'].join(', ') %>
+<% rule.each do |rule_name, rule_value| -%>
+<% if rule_value.kind_of?(Array) -%>
+<%= rule_name %> = <%= rule_value.join(', ') %>
+<% else -%>
+<%= rule_name %> = <%= rule_value %>
+<% end; end -%>
 <% end %>


### PR DESCRIPTION
We can now add any option to the relay rules for example this config:
```
gr_relay_rules      = {
        'skyline_haproxy'  => {
            pattern      => '^regex\.infrastructure\.haproxy\..*',
            destinations => [ '4.5.6.7:port:cache' ],
            continue     => true
        },
        'community'        => {
            pattern      => '^regex\.community\..+',
            destinations => [ '3.4.5.6:port:cache', '2.3.4.5:port:cache' ]
        },
        'default'          => {
            'default'    => true,
            destinations => [ '1.2.3.4:port:cache' ]
        }
}
```
BTW:
why do we sort these rules by name?
```
rules.sort.each do |name, rule|
```
If we skip the sort, we can rely on the sorting of the hash in puppet?!