### PR TITLE
change case of osfamily

### DIFF
--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -34,6 +34,7 @@ class graphite::config_apache inherits graphite::params {
           command => 'a2enmod headers',
           creates => '/etc/apache2/mods-enabled/headers.load',
           require => Package[$::graphite::params::apache_wsgi_pkg],
+          notify  => Service[$::graphite::params::apache_service_name];
         }
       }
 
@@ -78,8 +79,8 @@ class graphite::config_apache inherits graphite::params {
         Exec['Chown graphite for web user'],
         Exec['Initial django db creation'],
         Package[$::graphite::params::apache_wsgi_pkg],
-      ];
-
+      ],
+      notify  => Service[$::graphite::params::apache_service_name];
     "${::graphite::params::apacheconf_dir}/graphite.conf":
       ensure  => file,
       content => template($::graphite::gr_apache_conf_template),
@@ -88,7 +89,8 @@ class graphite::config_apache inherits graphite::params {
       owner   => $::graphite::params::web_user,
       require => [
         File["${::graphite::params::apache_dir}/ports.conf"],
-      ];
+      ],
+      notify  => Service[$::graphite::params::apache_service_name];
   }
 
   case $::osfamily {

--- a/manifests/config_gunicorn.pp
+++ b/manifests/config_gunicorn.pp
@@ -10,7 +10,8 @@
 class graphite::config_gunicorn inherits graphite::params {
   Exec { path => '/bin:/usr/bin:/usr/sbin' }
 
-  if $::osfamily == 'debian' {
+  if $::osfamily == 'Debian' {
+
     package {
       'gunicorn':
         ensure => installed,
@@ -40,11 +41,13 @@ class graphite::config_gunicorn inherits graphite::params {
       notify  => Service['gunicorn'],
       require => Package['gunicorn'],
     }
-  } elsif $::osfamily == 'redhat' {
-    package { 'python-gunicorn':
-      ensure => installed,
-      before => Exec['Chown graphite for web user'],
-      notify => Exec['Chown graphite for web user'],
+  } elsif $::osfamily == 'RedHat' {
+
+    package {
+      'python-gunicorn':
+        ensure => installed,
+        before => Exec['Chown graphite for web user'],
+        notify => Exec['Chown graphite for web user'];
     }
   } else {
     fail("wsgi/gunicorn-based graphite is not supported on ${::operatingsystem} (only supported on Debian & RedHat)")

--- a/manifests/config_nginx.pp
+++ b/manifests/config_nginx.pp
@@ -10,7 +10,7 @@
 class graphite::config_nginx inherits graphite::params {
   Exec { path => '/bin:/usr/bin:/usr/sbin' }
 
-  if $::osfamily != 'debian' {
+  if $::osfamily != 'Debian' {
     fail("nginx-based graphite is not supported on ${::operatingsystem} (only supported on Debian)")
   }
 


### PR DESCRIPTION
This was an old change i made to fix an issue where you had single quotes instead of double quotes.  however looks like you already fixed this.  I also updated a few minor things to add some service notifies and normalizes the case of osfamily so thought i would still send it along