### PR TITLE
Upstream

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,9 @@
 # [*gr_cache_query_port*]
 #   Self explaining.
 #   Default is 7002.
+# [*gr_cache_write_strategy*]
+#   The thread that writes metrics to disk can use on of the following strategies: sorted, max and naive.
+#   Default is 'sorted'.
 # [*gr_timezone*]
 #   Timezone for graphite to be used.
 #   Default is GMT.
@@ -386,6 +389,7 @@ class graphite (
   $gr_blacklist                          = [ ],
   $gr_cache_query_interface              = '0.0.0.0',
   $gr_cache_query_port                   = 7002,
+  $gr_cache_write_strategy               = 'sorted',
   $gr_timezone                           = 'GMT',
   $gr_storage_schemas                    = [
     {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,6 +59,7 @@ class graphite::params {
       $gweb_pip_hack_target   = "/opt/graphite/webapp/graphite_web-${graphiteVersion}-py2.7.egg-info"
 
       $graphitepkgs = [
+        'python-tz',
         'python-cairo',
         'python-django',
         'python-ldap',

--- a/templates/opt/graphite/conf/carbon.conf.erb
+++ b/templates/opt/graphite/conf/carbon.conf.erb
@@ -132,7 +132,7 @@ LOG_CACHE_QUEUE_SORTS = True
 # the OS's i/o scheduler is expected to compensate for the random write
 # pattern.
 #
-CACHE_WRITE_STRATEGY = sorted
+CACHE_WRITE_STRATEGY = <%= scope.lookupvar('graphite::gr_cache_write_strategy') %>
 
 # On some systems it is desirable for whisper to write synchronously.
 # Set this option to True if you'd like to try this. Basically it will


### PR DESCRIPTION
- Option to set write strategy

- python-tz (pytz) is required for graphite >= 0.9.13.
It should be ok to install it with older versions as well