### PR TITLE
Support installing via something other than pip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,3 @@ gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
 gem 'facter', '>= 1.7.0'
-
-gem 'beaker'
-gem 'beaker-rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
 gem 'facter', '>= 1.7.0'
+
+gem 'beaker'
+gem 'beaker-rspec'

--- a/README.md
+++ b/README.md
@@ -148,6 +148,27 @@ ones set for the principal instance.
 
 So in this case you would have 3 cache instances, the first one is `cache` (you can refer to it as `cache:a` too), `cache:b` and `cache:c`. cache:a will listen on ports 2003, 2004 and 7002 for line, pickle and query respectively. But, cache:b will do it on ports 2103, 2104, and 7102, and cache:c on 2203, 2204 and 7202. All other parameters from cache:a will be inherited by cache:b and c.
 
+###Installing with something other than pip and specifying package names and versions
+If you need to install via something other pip, an internal apt repo with fpm converted packages for instance, you can set `gr_pip_install` to false.
+If you're doing this you'll most likely have to override the default package names and versions as well. 
+```puppet
+  class { '::graphite':
+    gr_pip_install        => false,
+    gr_django_tagging_pkg => 'python-django-tagging',
+    gr_django_tagging_ver => 'present',
+    gr_twisted_pkg        => 'python-twisted',
+    gr_twisted_ver        => 'present',
+    gr_txamqp_pkg         => 'python-txamqp',
+    gr_txamqp_ver         => 'present',
+    gr_graphite_pkg       => 'python-graphite-web',
+    gr_graphite_ver       => 'present',
+    gr_carbon_pkg         => 'python-carbon',
+    gr_carbon_ver         => 'present',
+    gr_whisper_pkg        => 'python-whisper',
+    gr_whisper_ver        => 'present',
+  }
+```
+
 ##Usage
 
 ####Class: `graphite`
@@ -604,17 +625,70 @@ Default is false. Set lock writes for whisper
 
 Default is false. Set fallocate_create for whisper
 
-#####'gr_log_cache_performance'
+#####`gr_log_cache_performance`
 
 Default is 'False' (string). Logs timings for remote calls to carbon-cache
 
-#####'gr_log_rendering_performance'
+#####`gr_log_rendering_performance`
 
 Default is 'False' (string). Triggers the creation of rendering.log which logs timings for calls to the The Render URL API
 
-#####'gr_log_metric_access'
+#####`gr_log_metric_access`
 
 Default is 'False' (string). Trigges the creation of metricaccess.log which logs access to Whisper and RRD data files
+
+#####`gr_django_tagging_pkg`
+
+Default is 'django-tagging' (string) The name of the django-tagging package that should be installed
+
+#####`gr_django_tagging_ver`
+
+Default is '0.3.1' (string) The version of the django-tagging package that should be installed
+
+#####`gr_twisted_pkg`
+
+Default is 'Twisted' (string) The name of the twisted package that should be installed
+
+#####`gr_twisted_ver`
+
+Default is '11.1.0' (string) The version of the twisted package that should be installed
+
+#####`gr_txamqp_pkg`
+
+Default is 'txAMQP' (string) The name of the txamqp package that should be installed
+
+#####`gr_txamqp_ver`
+
+Default is '0.4' (string) The version of the txamqp package that should be installed
+
+#####`gr_graphite_pkg`
+
+Default is 'graphite-web' (string) The name of the graphite package that should be installed
+
+#####`gr_graphite_ver`
+
+Default is '0.9.12' (string) The version of the graphite package that should be installed
+
+#####`gr_carbon_pkg`
+
+Default is 'carbon' (string) The name of the carbon package that should be installed
+
+#####`gr_carbon_ver`
+
+Default is '0.9.12' (string) The version of the carbon package that should be installed
+
+#####`gr_whisper_pkg`
+
+Default is 'whisper' (string) The name of the whisper package that should be installed
+
+#####`gr_whisper_ver`
+
+Default is '0.9.12' (string) The version of the whisper package that should be installed
+
+#####`gr_pip_install`
+
+Default is true (Bool). Should packages be installed via pip
+
 
 ##Requirements
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -359,6 +359,9 @@
 #   and RRD data files
 #   Default is 'False' (String)
 #
+# [*gr_pip_instal*]
+#   
+#
 # === Examples
 #
 # class {'graphite':
@@ -520,6 +523,19 @@ class graphite (
   $gr_log_cache_performance              = 'False',
   $gr_log_rendering_performance          = 'False',
   $gr_log_metric_access                  = 'False',
+  $gr_pip_install                        = 'True',
+  $gr_django_tagging_pkg                 = $::graphite::params::django_tagging_pkg,
+  $gr_django_tagging_ver                 = $::graphite::params::django_tagging_ver,
+  $gr_twisted_pkg                        = $::graphite::params::twisted_pkg,
+  $gr_twisted_ver                        = $::graphite::params::twisted_ver,
+  $gr_txamqp_pkg                         = $::graphite::params::txamqp_pkg,
+  $gr_txamqp_ver                         = $::graphite::params::txamqp_ver,
+  $gr_graphite_pkg                       = $::graphite::params::graphite_pkg,
+  $gr_graphite_ver                       = $::graphite::params::graphite_ver,
+  $gr_carbon_pkg                         = $::graphite::params::carbon_pkg,
+  $gr_carbon_ver                         = $::graphite::params::carbon_ver,
+  $gr_whisper_pkg                        = $::graphite::params::whisper_pkg,
+  $gr_whisper_ver                        = $::graphite::params::whisper_ver,
 ) inherits graphite::params {
   # Validation of input variables.
   # TODO - validate all the things

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -358,9 +358,45 @@
 #   Trigges the creation of metricaccess.log which logs access to Whisper
 #   and RRD data files
 #   Default is 'False' (String)
-#
-# [*gr_pip_instal*]
-#   
+# [*gr_django_tagging_pkg*]
+#   String. The name of the django tagging package to install
+#   Default: django-tagging
+# [*gr_django_tagging_ver*] 
+#   String. The version of the django tagging package to install
+#   Default: 0.3.1
+# [*gr_twisted_pkg*]
+#   String. The name of the twisted package to install
+#   Default: Twisted
+# [*gr_twisted_ver*] 
+#   String. The version of the twisted package to install
+#   Default: 11.1.0
+# [*gr_txamqp_pkg*]
+#   String. The name of the txamqp package to install
+#   Default: txAMQP
+# [*gr_txamqp_ver*] 
+#   String. The version of the txamqp package to install
+#   Default: 0.4
+# [*gr_graphite_pkg*]
+#   String. The name of the graphite package to install
+#   Default: graphite-web
+# [*gr_graphite_ver*] 
+#   String. The version of the graphite package to install
+#   Default: 0.9.12
+# [*gr_carbon_pkg*]
+#   String. The name of the carbon package to install
+#   Default: carbon
+# [*gr_carbon_ver*] 
+#   String. The version of the carbon package to install
+#   Default: 0.9.12
+# [*gr_whisper_pkg*]
+#   String. The name of the whisper package to install
+#   Default: whisper
+# [*gr_whisper_ver*] 
+#   String. The version of the whisper package to install
+#   Default: 0.9.12
+# [*gr_pip_install*]
+#   Boolean. Should the package be installed via pip
+#   Default: true  
 #
 # === Examples
 #
@@ -523,7 +559,6 @@ class graphite (
   $gr_log_cache_performance              = 'False',
   $gr_log_rendering_performance          = 'False',
   $gr_log_metric_access                  = 'False',
-  $gr_pip_install                        = 'True',
   $gr_django_tagging_pkg                 = $::graphite::params::django_tagging_pkg,
   $gr_django_tagging_ver                 = $::graphite::params::django_tagging_ver,
   $gr_twisted_pkg                        = $::graphite::params::twisted_pkg,
@@ -536,6 +571,7 @@ class graphite (
   $gr_carbon_ver                         = $::graphite::params::carbon_ver,
   $gr_whisper_pkg                        = $::graphite::params::whisper_pkg,
   $gr_whisper_ver                        = $::graphite::params::whisper_ver,
+  $gr_pip_install                        = true,
 ) inherits graphite::params {
   # Validation of input variables.
   # TODO - validate all the things

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,17 +6,9 @@
 #
 # None.
 #
-class graphite::install(
-  $django_tagging_ver = '0.3.1',
-  $twisted_ver        = '11.1.0',
-  $txamqp_ver         = '0.4',
-) inherits graphite::params {
+class graphite::install inherits graphite::params {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
-  }
-
-  Package {
-    provider => 'pip',
   }
 
   # for full functionality we need these packages:
@@ -24,29 +16,35 @@ class graphite::install(
   #           python-django-tagging, python-simplejson
   # optinal: python-ldap, python-memcache, memcached, python-sqlite
 
-  # using the pip package provider requires python-pip
-
-  if ! defined(Package[$::graphite::params::python_pip_pkg]) {
-    package { $::graphite::params::python_pip_pkg :
-      provider => undef, # default to package provider auto-discovery
-      before   => [
-        Package['django-tagging'],
-        Package['twisted'],
-        Package['txamqp'],
-      ]
+  if $::graphite::gr_pip_install {
+    Package {
+      provider => 'pip',
     }
-  }
 
-  # install python headers and libs for pip
+    # using the pip package provider requires python-pip
 
-  if ! defined(Package[$::graphite::params::python_dev_pkg]) {
-    package { $::graphite::params::python_dev_pkg :
-      provider => undef, # default to package provider auto-discovery
-      before   => [
-        Package['django-tagging'],
-        Package['twisted'],
-        Package['txamqp'],
-      ]
+    if ! defined(Package[$::graphite::params::python_pip_pkg]) {
+      package { $::graphite::params::python_pip_pkg :
+        provider => undef, # default to package provider auto-discovery
+        before   => [
+          Package['django-tagging'],
+          Package['twisted'],
+          Package['txamqp'],
+        ]
+      }
+    }
+
+    # install python headers and libs for pip
+
+    if ! defined(Package[$::graphite::params::python_dev_pkg]) {
+      package { $::graphite::params::python_dev_pkg :
+        provider => undef, # default to package provider auto-discovery
+        before   => [
+          Package['django-tagging'],
+          Package['twisted'],
+          Package['txamqp'],
+        ]
+      }
     }
   }
 
@@ -55,41 +53,49 @@ class graphite::install(
     provider => undef, # default to package provider auto-discovery
   }->
 
-  package{'django-tagging':
-    ensure => $django_tagging_ver,
+  package{ 'django-tagging':
+      ensure => $::graphite::gr_django_tagging_ver,
+      name   => $::graphite::gr_django_tagging_pkg,
   }->
 
   package{'twisted':
-    ensure => $twisted_ver,
-    name   => 'Twisted',
+    ensure => $::graphite::gr_twisted_ver,
+    name   => $::graphite::gr_twisted_pkg,
   }->
 
   package{'txamqp':
-    ensure => $txamqp_ver,
-    name   => 'txAMQP',
+    ensure => $::graphite::gr_txamqp_ver,
+    name   => $::graphite::gr_txamqp_pkg,
   }->
 
   package{'graphite-web':
-    ensure => $::graphite::params::graphiteVersion,
+    ensure => $::graphite::gr_graphite_ver,
+    name   => $::graphite::gr_graphite_pkg,
   }->
 
   package{'carbon':
-    ensure => $::graphite::params::carbonVersion,
+    ensure => $::graphite::gr_carbon_ver,
+    name   => $::graphite::gr_carbon_pkg,
   }->
 
   package{'whisper':
-    ensure => $::graphite::params::whisperVersion,
-  }->
+    ensure => $::graphite::gr_whisper_ver,
+    name   => $::graphite::gr_whisper_pkg,
+  }
 
-  # workaround for unusual graphite install target:
-  # https://github.com/graphite-project/carbon/issues/86
-  file { $::graphite::params::carbon_pip_hack_source :
-    ensure => link,
-    target => $::graphite::params::carbon_pip_hack_target,
-  }->
+  if $::graphite::gr_pip_install {
+    # workaround for unusual graphite install target:
+    # https://github.com/graphite-project/carbon/issues/86
+    file { $::graphite::params::carbon_pip_hack_source :
+      ensure  => link,
+      target  => $::graphite::params::carbon_pip_hack_target,
+      require => Package['whisper'],
+    }
 
-  file { $::graphite::params::gweb_pip_hack_source :
-    ensure => link,
-    target => $::graphite::params::gweb_pip_hack_target,
+    file { $::graphite::params::gweb_pip_hack_source :
+      ensure  => link,
+      target  => $::graphite::params::gweb_pip_hack_target,
+      require => Package['whisper'],
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,14 +24,14 @@ class graphite::params {
   $whisper_pkg        = 'whisper'
   $whisper_ver        = '0.9.12'
 
-  $whisper_dl_url = "http://github.com/graphite-project/whisper/archive/${::graphite::params::whisperVersion}.tar.gz"
-  $whisper_dl_loc = "${build_dir}/whisper-${::graphite::params::whisperVersion}"
+  $whisper_dl_url = "http://github.com/graphite-project/whisper/archive/${::graphite::params::whisper_ver}.tar.gz"
+  $whisper_dl_loc = "${build_dir}/whisper-${::graphite::params::whisper_ver}"
 
-  $webapp_dl_url = "http://github.com/graphite-project/graphite-web/archive/${::graphite::params::graphiteVersion}.tar.gz"
-  $webapp_dl_loc = "${build_dir}/graphite-web-${::graphite::params::graphiteVersion}"
+  $webapp_dl_url = "http://github.com/graphite-project/graphite-web/archive/${::graphite::params::graphite_ver}.tar.gz"
+  $webapp_dl_loc = "${build_dir}/graphite-web-${::graphite::params::graphite_ver}"
 
-  $carbon_dl_url = "https://github.com/graphite-project/carbon/archive/${::graphite::params::carbonVersion}.tar.gz"
-  $carbon_dl_loc = "${build_dir}/carbon-${::graphite::params::carbonVersion}"
+  $carbon_dl_url = "https://github.com/graphite-project/carbon/archive/${::graphite::params::carbon_ver}.tar.gz"
+  $carbon_dl_loc = "${build_dir}/carbon-${::graphite::params::carbon_ver}"
 
   $install_prefix      = '/opt/'
   $enable_carbon_relay = false
@@ -62,10 +62,10 @@ class graphite::params {
       $python_dev_pkg = 'python-dev'
 
       # see https://github.com/graphite-project/carbon/issues/86
-      $carbon_pip_hack_source = "/usr/lib/python2.7/dist-packages/carbon-${carbonVersion}-py2.7.egg-info"
-      $carbon_pip_hack_target = "/opt/graphite/lib/carbon-${carbonVersion}-py2.7.egg-info"
-      $gweb_pip_hack_source   = "/usr/lib/python2.7/dist-packages/graphite_web-${graphiteVersion}-py2.7.egg-info"
-      $gweb_pip_hack_target   = "/opt/graphite/webapp/graphite_web-${graphiteVersion}-py2.7.egg-info"
+      $carbon_pip_hack_source = "/usr/lib/python2.7/dist-packages/carbon-${carbon_ver}-py2.7.egg-info"
+      $carbon_pip_hack_target = "/opt/graphite/lib/carbon-${carbon_ver}-py2.7.egg-info"
+      $gweb_pip_hack_source   = "/usr/lib/python2.7/dist-packages/graphite_web-${graphite_ver}-py2.7.egg-info"
+      $gweb_pip_hack_target   = "/opt/graphite/webapp/graphite_web-${graphite_ver}-py2.7.egg-info"
 
       $graphitepkgs = [
         'python-tz',
@@ -120,11 +120,11 @@ class graphite::params {
       # see https://github.com/graphite-project/carbon/issues/86
       case $::operatingsystemrelease {
         /^6\.\d+$/: {
-          $carbon_pip_hack_source     = "/usr/lib/python2.6/site-packages/carbon-${carbonVersion}-py2.6.egg-info"
-          $carbon_pip_hack_target     = "/opt/graphite/lib/carbon-${carbonVersion}-py2.6.egg-info"
+          $carbon_pip_hack_source     = "/usr/lib/python2.6/site-packages/carbon-${carbon_ver}-py2.6.egg-info"
+          $carbon_pip_hack_target     = "/opt/graphite/lib/carbon-${carbon_ver}-py2.6.egg-info"
           $apache_24               = false
-          $gweb_pip_hack_source       = "/usr/lib/python2.6/site-packages/graphite_web-${graphiteVersion}-py2.6.egg-info"
-          $gweb_pip_hack_target       = "/opt/graphite/webapp/graphite_web-${graphiteVersion}-py2.6.egg-info"
+          $gweb_pip_hack_source       = "/usr/lib/python2.6/site-packages/graphite_web-${graphite_ver}-py2.6.egg-info"
+          $gweb_pip_hack_target       = "/opt/graphite/webapp/graphite_web-${graphite_ver}-py2.6.egg-info"
           $graphitepkgs = [
             'Django14',
             'MySQL-python',
@@ -143,11 +143,11 @@ class graphite::params {
         }
 
         /^7\.\d+/: {
-          $carbon_pip_hack_source     = "/usr/lib/python2.7/site-packages/carbon-${carbonVersion}-py2.7.egg-info"
-          $carbon_pip_hack_target     = "/opt/graphite/lib/carbon-${carbonVersion}-py2.7.egg-info"
+          $carbon_pip_hack_source     = "/usr/lib/python2.7/site-packages/carbon-${carbon_ver}-py2.7.egg-info"
+          $carbon_pip_hack_target     = "/opt/graphite/lib/carbon-${carbon_ver}-py2.7.egg-info"
           $apache_24               = true
-          $gweb_pip_hack_source       = "/usr/lib/python2.7/site-packages/graphite_web-${graphiteVersion}-py2.7.egg-info"
-          $gweb_pip_hack_target       = "/opt/graphite/webapp/graphite_web-${graphiteVersion}-py2.7.egg-info"
+          $gweb_pip_hack_source       = "/usr/lib/python2.7/site-packages/graphite_web-${graphite_ver}-py2.7.egg-info"
+          $gweb_pip_hack_target       = "/opt/graphite/webapp/graphite_web-${graphite_ver}-py2.7.egg-info"
           $graphitepkgs = [
             'python-django',
             'MySQL-python',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,10 +10,19 @@
 class graphite::params {
   $build_dir = '/usr/local/src/'
 
-  $python_pip_pkg  = 'python-pip'
-  $graphiteVersion = '0.9.12'
-  $carbonVersion   = '0.9.12'
-  $whisperVersion  = '0.9.12'
+  $python_pip_pkg     = 'python-pip'
+  $django_tagging_pkg = 'django_tagging'
+  $django_tagging_ver = '0.3.1'
+  $twisted_pkg        = 'Twisted'
+  $twisted_ver        = '11.1.0'
+  $txamqp_pkg         = 'txAMQP'
+  $txamqp_ver         = '0.4'
+  $graphite_pkg       = 'graphite-web'
+  $graphite_ver       = '0.9.12'
+  $carbon_pkg         = 'carbon'
+  $carbon_ver         = '0.9.12'
+  $whisper_pkg        = 'whisper'
+  $whisper_ver        = '0.9.12'
 
   $whisper_dl_url = "http://github.com/graphite-project/whisper/archive/${::graphite::params::whisperVersion}.tar.gz"
   $whisper_dl_loc = "${build_dir}/whisper-${::graphite::params::whisperVersion}"
@@ -68,7 +77,6 @@ class graphite::params {
         'python-psycopg2',
         'python-simplejson',
         'python-sqlite',
-        'python-twisted',
       ]
 
       case $::lsbdistcodename {


### PR DESCRIPTION
I work in an environment where the servers aren't allowed outbound network access for security reasons.  This makes installing via pip an issue. This PR allows installing via alternate methods.  The default functionality is unchanged. 