### PR TITLE
Added options to install graphite components from alternative locations....

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -532,6 +532,9 @@ class graphite (
   $wsgi_processes                        =  5,
   $wsgi_threads                          =  5,
   $wsgi_inactivity_timeout               =  120,
+  $gr_graphite_web_loc                   = undef,
+  $gr_carbon_loc                         = undef,
+  $gr_whisper_loc                        = undef,
 ) inherits graphite::params {
   # Validation of input variables.
   # TODO - validate all the things
@@ -543,7 +546,11 @@ class graphite (
   # the composite class.
   # https://projects.puppetlabs.com/projects/puppet/wiki/Anchor_Pattern
   anchor { 'graphite::begin':}->
-  class { 'graphite::install':}~>
+  class { 'graphite::install':
+    graphite_web_loc   => $gr_graphite_web_loc,
+    carbon_loc         => $gr_carbon_loc,
+    whisper_loc        => $gr_whisper_loc,
+  }~>
   class { 'graphite::config':}->
   anchor { 'graphite::end':}
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -607,6 +607,7 @@ class graphite (
   # the composite class.
   # https://projects.puppetlabs.com/projects/puppet/wiki/Anchor_Pattern
   anchor { 'graphite::begin':}->
+  class { 'graphite::install':}~>
   class { 'graphite::config':}->
   anchor { 'graphite::end':}
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,6 +10,9 @@ class graphite::install(
   $django_tagging_ver = '0.3.1',
   $twisted_ver        = '11.1.0',
   $txamqp_ver         = '0.4',
+  $graphite_web_loc   = 'graphite-web',
+  $carbon_loc         = 'carbon',
+  $whisper_loc        = 'whisper',
 ) inherits graphite::params {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
@@ -70,15 +73,18 @@ class graphite::install(
   }->
 
   package{'graphite-web':
-    ensure => $::graphite::params::graphiteVersion,
+    ensure => installed,
+    name => $graphite_web_loc,
   }->
 
   package{'carbon':
-    ensure => $::graphite::params::carbonVersion,
+    ensure => installed,
+    name => $carbon_loc,
   }->
 
   package{'whisper':
-    ensure => $::graphite::params::whisperVersion,
+    ensure => installed,
+    name => $whisper_loc
   }->
 
   # workaround for unusual graphite install target:

--- a/templates/etc/apache2/sites-available/graphite.conf.erb
+++ b/templates/etc/apache2/sites-available/graphite.conf.erb
@@ -36,6 +36,8 @@ WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefi
 	WSGIScriptAlias / /opt/graphite/conf/graphite.wsgi
 
 	Alias /content/ /opt/graphite/webapp/content/
+    Alias /static/ /opt/graphite/webapp/content/
+
 	<Location "/content/">
 			SetHandler None
 <% if scope.lookupvar('graphite::gr_apache_24') %>

--- a/templates/opt/graphite/webapp/graphite/local_settings.py.erb
+++ b/templates/opt/graphite/webapp/graphite/local_settings.py.erb
@@ -274,5 +274,5 @@ end
 
 <% unless scope.lookupvar('graphite::gr_django_1_4_or_less') %>
 # Configure static URL prefix for Django admin pages
-STATIC_URL = '/static/'
+STATIC_URL = '/content/'
 <% end %>


### PR DESCRIPTION
E.g. from git repository.

Call example:

    class { 'graphite':
        gr_graphite_web_loc => "git+https://github.com/graphite-project/graphite-web.git@0.9.12",
        gr_carbon_loc       => "git+https://github.com/graphite-project/carbon.git@0.9.12",
        gr_whisper_loc      => 'git+https://github.com/graphite-project/whisper.git@0.9.12',
    }