### PR TITLE
Logrotate filtering out .gz files

### DIFF
--- a/templates/opt/graphite/bin/carbon-logrotate.sh.erb
+++ b/templates/opt/graphite/bin/carbon-logrotate.sh.erb
@@ -6,6 +6,6 @@
 CARBON_LOGS=/opt/graphite/storage/log/carbon-cache/
 
 # gzip log files older than 3 days
-find $CARBON_LOGS -type f -mtime +3 -exec gzip -q "{}" \;
+find $CARBON_LOGS -type f -mtime +3 -regex ".*[^gz]$" -exec gzip -q "{}" \;
 # removes log files older than 30 days
 find $CARBON_LOGS -type f -ctime +30 -exec rm "{}" \;


### PR DESCRIPTION
We are getting this error

```
gzip: /opt/graphite/storage/log/carbon-cache/carbon-cache-cache/console.log.gz already exists;  not overwritten
```

Because the logrotate script is not filtering out already gzipped files, this should fix the problem.