### PR TITLE
Fixes #155

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,8 +11,8 @@ class graphite::params {
   $build_dir = '/usr/local/src/'
 
   $python_pip_pkg     = 'python-pip'
-  $django_tagging_pkg = 'django_tagging'
-  $django_tagging_ver = '0.3.1'
+  $django_tagging_pkg = 'django-tagging'
+  $django_tagging_ver = '0.3.4'
   $twisted_pkg        = 'Twisted'
   $twisted_ver        = '11.1.0'
   $txamqp_pkg         = 'txAMQP'


### PR DESCRIPTION
It seems like they changed the naming of the django-tagging module in pip.
This solved my problem.
Only been tested on Ubuntu 14.04.2 LTS - Puppet 3.7.4 though.