### PR TITLE
Fix the namespace of the virtualenv variable

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,10 +3,10 @@ fixtures:
     stdlib: 
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
       ref: "4.2.0"
-    apache: 
+    apache:
       repo: "git://github.com/puppetlabs/puppetlabs-apache.git"
       ref: "1.2.0"
-    concat: 
+    concat:
       repo: "git://github.com/puppetlabs/puppetlabs-concat.git"
       ref: "1.1.1"
     logrotate:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,13 +10,24 @@
 class graphite::config inherits graphite::params {
   Exec { path => '/bin:/usr/bin:/usr/sbin' }
 
-  # This variable will be used in init scripts to 
-  # invoke virtualenv if enabled by $python_provider
+  # If virtualenv is used, then the environment must
+  # be considered carefully for other operations
   if $graphite::python_provider == 'virtualenv' {
+    # Set a local convenience variable
+    $_venv=$graphite::params::virtualenv
+
+    # This will be used in init scripts templates
     $venv_environment = [
-      "PATH=${::virtualenv}/bin:\$PATH",
-      "VIRTUAL_ENV=${::virtualenv}",
+      "PATH=${_venv}/bin:\$PATH",
+      "VIRTUAL_ENV=${_venv}",
     ]
+
+    # All Exec 'path' and 'environment' params need to
+    # include the VIRTUAL_ENV and PATH variables
+    Exec {
+      environment => "VIRTUAL_ENV=${_venv}",
+      path        => "${_venv}/bin:/bin:/usr/bin:/usr/sbin",
+    }
   } else {
     $venv_environment = []
   }
@@ -60,7 +71,6 @@ class graphite::config inherits graphite::params {
   # first init of user db for graphite
 
   exec { 'Initial django db creation':
-    environment => $venv_environment,
     command     => 'python manage.py syncdb --noinput',
     cwd         => '/opt/graphite/webapp/graphite',
     refreshonly => true,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,7 +8,6 @@
 # None.
 #
 class graphite::config inherits graphite::params {
-  Exec { path => '/bin:/usr/bin:/usr/sbin' }
 
   # If virtualenv is used, then the environment must
   # be considered carefully for other operations
@@ -30,6 +29,7 @@ class graphite::config inherits graphite::params {
     }
   } else {
     $venv_environment = []
+    Exec { path => '/bin:/usr/bin:/usr/sbin' }
   }
 
   # for full functionality we need this packages:

--- a/spec/classes/graphite_spec.rb
+++ b/spec/classes/graphite_spec.rb
@@ -9,7 +9,7 @@ describe 'graphite' do
 
   context 'RedHat supported platforms' do
     ['6.5','7.5'].each do | operatingsystemrelease |
-      let(:facts) {{ :osfamily => 'RedHat', :operatingsystemrelease => operatingsystemrelease}}
+      let(:facts) {{ :osfamily => 'RedHat', :operatingsystemrelease => operatingsystemrelease, :concat_basedir => '/dummy/path' }}
       describe "Release #{operatingsystemrelease}" do
         it { should contain_anchor('graphite::begin') }
         it { should contain_class('graphite::install') }
@@ -21,7 +21,7 @@ describe 'graphite' do
 
   context 'RedHat unsupported platforms' do
     ['5.0'].each do | operatingsystemrelease |
-      let(:facts) {{ :osfamily => 'RedHat', :operatingsystemrelease => operatingsystemrelease}}
+      let(:facts) {{ :osfamily => 'RedHat', :operatingsystemrelease => operatingsystemrelease }}
       describe "Redhat #{operatingsystemrelease} fails" do
         it { expect { should contain_class('graphite')}.to raise_error(Puppet::Error, /Unsupported RedHat release/) }
       end
@@ -30,7 +30,7 @@ describe 'graphite' do
 
   context 'Debian supported platforms' do
     ['trusty','squeeze'].each do | lsbdistcodename |
-      let(:facts) {{ :osfamily => 'Debian', :lsbdistcodename => lsbdistcodename}}
+      let(:facts) {{ :osfamily => 'Debian', :lsbdistcodename => lsbdistcodename, :concat_basedir => '/dummy/path' }}
       describe "Lsbdistcodename #{lsbdistcodename}" do
         it { should contain_anchor('graphite::begin') }
         it { should contain_class('graphite::install') }


### PR DESCRIPTION
This was committed incorrectly the first time around.  Use of the top-scope namespace resolves to nil, i.e. ```$::virtualenv``` is busted.
  - Instead use ```$graphite::params::virtualenv``` to avoid puppet lint errors.
  - This variable is populated through inheritance of ```graphite::params```