### PR TITLE
Fix init script error for Redhat and fix some bash style

### DIFF
--- a/templates/etc/init.d/Debian/carbon-aggregator.erb
+++ b/templates/etc/init.d/Debian/carbon-aggregator.erb
@@ -20,9 +20,9 @@ STOP_COUNTER=12 # 12 times 5s -> 60 secs
 OPERATION="$1"
 if [ $# -gt 1 ]; then
     shift
-    INSTANCES=$@
+    INSTANCES=$*
 else
-    INSTANCES=`grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2`
+    INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
 fi
 
 case "${OPERATION}" in
@@ -35,16 +35,16 @@ case "${OPERATION}" in
         for INSTANCE in ${INSTANCES}; do
             ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop
             sleep 3
-            CNT=$STOP_COUNTER
-            while [ `/usr/bin/pgrep -cf "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}"` -eq 1 ]; do
+            CNT=${STOP_COUNTER}
+            while [ $(/usr/bin/pgrep -cf "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}") -eq 1 ]; do
                 echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
                 sleep 5
-                if [ $CNT -lt 1 ]; then
-                    pid=`/usr/bin/pgrep -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}"`
-                    test -n $pid && kill -9 $pid
+                if [ ${CNT} -lt 1 ]; then
+                    pid=$(/usr/bin/pgrep -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}")
+                    test -n ${pid} && kill -9 ${pid}
                     break
                 fi
-                CNT=`expr ${CNT} - 1`
+                CNT=$(expr ${CNT} - 1)
             done
         done
         ;;
@@ -54,7 +54,7 @@ case "${OPERATION}" in
         done
         ;;
     restart)
-        $0 stop $INSTANCES && sleep 2 && $0 start $INSTANCES
+        $0 stop ${INSTANCES} && sleep 2 && $0 start ${INSTANCES}
         ;;
     *)
         echo "Usage: $0 {start|stop|restart|status} [instance instance ...]"

--- a/templates/etc/init.d/Debian/carbon-cache.erb
+++ b/templates/etc/init.d/Debian/carbon-cache.erb
@@ -20,9 +20,9 @@ STOP_COUNTER=12 # 12 times 5s -> 60 secs
 OPERATION="$1"
 if [ $# -gt 1 ]; then
     shift
-    INSTANCES=$@
+    INSTANCES=$*
 else
-    INSTANCES=`grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2`
+    INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
 fi
 
 case "${OPERATION}" in
@@ -35,16 +35,16 @@ case "${OPERATION}" in
         for INSTANCE in ${INSTANCES}; do
             ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop
             sleep 3
-            CNT=$STOP_COUNTER
-            while [ `/usr/bin/pgrep -cf "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}"` -eq 1 ]; do
+            CNT=${STOP_COUNTER}
+            while [ $(/usr/bin/pgrep -cf "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}") -eq 1 ]; do
                 echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
                 sleep 5
-                if [ $CNT -lt 1 ]; then
-                    pid=`/usr/bin/pgrep -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}"`
-                    test -n $pid && kill -9 $pid
+                if [ ${CNT} -lt 1 ]; then
+                    pid=$(/usr/bin/pgrep -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}")
+                    test -n ${pid} && kill -9 ${pid}
                     break
                 fi
-                CNT=`expr ${CNT} - 1`
+                CNT=$(expr ${CNT} - 1)
             done
         done
         ;;
@@ -54,7 +54,7 @@ case "${OPERATION}" in
         done
         ;;
     restart)
-        $0 stop $INSTANCES && sleep 2 && $0 start $INSTANCES
+        $0 stop ${INSTANCES} && sleep 2 && $0 start ${INSTANCES}
         ;;
     *)
         echo "Usage: $0 {start|stop|restart|status} [instance instance ...]"

--- a/templates/etc/init.d/Debian/carbon-relay.erb
+++ b/templates/etc/init.d/Debian/carbon-relay.erb
@@ -20,9 +20,9 @@ STOP_COUNTER=12 # 12 times 5s -> 60 secs
 OPERATION="$1"
 if [ $# -gt 1 ]; then
     shift
-    INSTANCES=$@
+    INSTANCES=$*
 else
-    INSTANCES=`grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2`
+    INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
 fi
 
 case "${OPERATION}" in
@@ -35,17 +35,16 @@ case "${OPERATION}" in
         for INSTANCE in ${INSTANCES}; do
             ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop
             sleep 3
-            CNT=$STOP_COUNTER
-            while [ `/usr/bin/pgrep -cf "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}"` -eq 1 ]; do
+            CNT=${STOP_COUNTER}
+            while [ $(/usr/bin/pgrep -cf "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}") -eq 1 ]; do
                 echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
                 sleep 5
-                if [ $CNT -lt 1 ];
-                then
-                    pid=`/usr/bin/pgrep -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}"`
-                    test -n $pid && kill -9 $pid
+                if [ ${CNT} -lt 1 ]; then
+                    pid=$(/usr/bin/pgrep -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}")
+                    test -n ${pid} && kill -9 ${pid}
                     break
                 fi
-                CNT=`expr ${CNT} - 1`
+                CNT=$(expr ${CNT} - 1)
             done
         done
         ;;
@@ -55,7 +54,7 @@ case "${OPERATION}" in
         done
         ;;
     restart)
-        $0 stop $INSTANCES && sleep 2 && $0 start $INSTANCES
+        $0 stop ${INSTANCES} && sleep 2 && $0 start ${INSTANCES}
         ;;
     *)
         echo "Usage: $0 {start|stop|restart|status} [instance instance ...]"

--- a/templates/etc/init.d/RedHat/carbon-aggregator.erb
+++ b/templates/etc/init.d/RedHat/carbon-aggregator.erb
@@ -26,9 +26,9 @@ pidfile=""
 OPERATION="$1"
 if [ $# -gt 1 ]; then
     shift
-    INSTANCES=$@
+    INSTANCES=$*
 else
-	INSTANCES=`grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2`
+	INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
 fi
 
 start()
@@ -46,7 +46,7 @@ start()
         retval=$?
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         echo -n $"Starting carbon-${CARBON_DAEMON}:${INSTANCE}..."
-        if [ rh_status_q ]; then
+        if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
             echo_success
             echo
@@ -111,7 +111,7 @@ restart() {
         retval=$?
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         echo -n $"Starting carbon-${CARBON_DAEMON}:${INSTANCE}..."
-        if [ rh_status_q ]; then
+        if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
             echo_success
             echo

--- a/templates/etc/init.d/RedHat/carbon-cache.erb
+++ b/templates/etc/init.d/RedHat/carbon-cache.erb
@@ -26,9 +26,9 @@ pidfile=""
 OPERATION="$1"
 if [ $# -gt 1 ]; then
     shift
-    INSTANCES=$@
+    INSTANCES=$*
 else
-	INSTANCES=`grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2`
+	INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
 fi
 
 start()
@@ -46,7 +46,7 @@ start()
         retval=$?
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         echo -n $"Starting carbon-${CARBON_DAEMON}:${INSTANCE}..."
-        if [ rh_status_q ]; then
+        if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
             echo_success
             echo
@@ -111,7 +111,7 @@ restart() {
         retval=$?
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         echo -n $"Starting carbon-${CARBON_DAEMON}:${INSTANCE}..."
-        if [ rh_status_q ]; then
+        if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
             echo_success
             echo

--- a/templates/etc/init.d/RedHat/carbon-relay.erb
+++ b/templates/etc/init.d/RedHat/carbon-relay.erb
@@ -26,9 +26,9 @@ pidfile=""
 OPERATION="$1"
 if [ $# -gt 1 ]; then
     shift
-    INSTANCES=$@
+    INSTANCES=$*
 else
-	INSTANCES=`grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2`
+	INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
 fi
 
 start()
@@ -46,7 +46,7 @@ start()
         retval=$?
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         echo -n $"Starting carbon-${CARBON_DAEMON}:${INSTANCE}..."
-        if [ rh_status_q ]; then
+        if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
             echo_success
             echo
@@ -111,7 +111,7 @@ restart() {
         retval=$?
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         echo -n $"Starting carbon-${CARBON_DAEMON}:${INSTANCE}..."
-        if [ rh_status_q ]; then
+        if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
             echo_success
             echo


### PR DESCRIPTION
The fix in the Redhat scripts is when "rh_status_q" is used as condition of an if. Between [] is treated as literal, no function, so it's always true.

Style changed to standards. I want to change more but I didn't, because we are using "sh" instead of "bash" (even if it is the same in the system where it's running, we cannot asure that always). For instance:

CNT=$(expr ${CNT} - 1)

is better expressed as:

((CNT--))
