### PR TITLE
Fix first carbon instance for every service

### DIFF
--- a/templates/etc/init.d/Debian/carbon-aggregator.erb
+++ b/templates/etc/init.d/Debian/carbon-aggregator.erb
@@ -23,6 +23,7 @@ if [ $# -gt 1 ]; then
     INSTANCES=$*
 else
     INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
+    INSTANCES=${INSTANCES/${CARBON_DAEMON}/a}
 fi
 
 case "${OPERATION}" in

--- a/templates/etc/init.d/Debian/carbon-cache.erb
+++ b/templates/etc/init.d/Debian/carbon-cache.erb
@@ -23,6 +23,7 @@ if [ $# -gt 1 ]; then
     INSTANCES=$*
 else
     INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
+    INSTANCES=${INSTANCES/${CARBON_DAEMON}/a}
 fi
 
 case "${OPERATION}" in

--- a/templates/etc/init.d/Debian/carbon-relay.erb
+++ b/templates/etc/init.d/Debian/carbon-relay.erb
@@ -23,6 +23,7 @@ if [ $# -gt 1 ]; then
     INSTANCES=$*
 else
     INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
+    INSTANCES=${INSTANCES/${CARBON_DAEMON}/a}
 fi
 
 case "${OPERATION}" in

--- a/templates/etc/init.d/RedHat/carbon-aggregator.erb
+++ b/templates/etc/init.d/RedHat/carbon-aggregator.erb
@@ -28,7 +28,7 @@ if [ $# -gt 1 ]; then
     shift
     INSTANCES=$*
 else
-	INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
+    INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
     INSTANCES=${INSTANCES/${CARBON_DAEMON}/a}
 fi
 
@@ -147,7 +147,7 @@ case "${OPERATION}" in
         ;;
     stop)
         $1
-		;;
+        ;;
     restart)
         $1
         ;;

--- a/templates/etc/init.d/RedHat/carbon-aggregator.erb
+++ b/templates/etc/init.d/RedHat/carbon-aggregator.erb
@@ -29,6 +29,7 @@ if [ $# -gt 1 ]; then
     INSTANCES=$*
 else
 	INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
+    INSTANCES=${INSTANCES/${CARBON_DAEMON}/a}
 fi
 
 start()

--- a/templates/etc/init.d/RedHat/carbon-cache.erb
+++ b/templates/etc/init.d/RedHat/carbon-cache.erb
@@ -28,7 +28,7 @@ if [ $# -gt 1 ]; then
     shift
     INSTANCES=$*
 else
-	INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
+    INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
     INSTANCES=${INSTANCES/${CARBON_DAEMON}/a}
 fi
 
@@ -147,7 +147,7 @@ case "${OPERATION}" in
         ;;
     stop)
         $1
-		;;
+        ;;
     restart)
         $1
         ;;

--- a/templates/etc/init.d/RedHat/carbon-cache.erb
+++ b/templates/etc/init.d/RedHat/carbon-cache.erb
@@ -29,6 +29,7 @@ if [ $# -gt 1 ]; then
     INSTANCES=$*
 else
 	INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
+    INSTANCES=${INSTANCES/${CARBON_DAEMON}/a}
 fi
 
 start()

--- a/templates/etc/init.d/RedHat/carbon-relay.erb
+++ b/templates/etc/init.d/RedHat/carbon-relay.erb
@@ -28,7 +28,7 @@ if [ $# -gt 1 ]; then
     shift
     INSTANCES=$*
 else
-	INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
+    INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
     INSTANCES=${INSTANCES/${CARBON_DAEMON}/a}
 fi
 
@@ -147,7 +147,7 @@ case "${OPERATION}" in
         ;;
     stop)
         $1
-		;;
+        ;;
     restart)
         $1
         ;;

--- a/templates/etc/init.d/RedHat/carbon-relay.erb
+++ b/templates/etc/init.d/RedHat/carbon-relay.erb
@@ -29,6 +29,7 @@ if [ $# -gt 1 ]; then
     INSTANCES=$*
 else
 	INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
+    INSTANCES=${INSTANCES/${CARBON_DAEMON}/a}
 fi
 
 start()


### PR DESCRIPTION
The list of INSTANCES variable was something like: "aggregator b c d" or "cache b c d"
First instance should be 'a': "a b c d"
Before fix, first instance was never started, stopped or restarted.