### PR TITLE
Handle permissions on /opt/graphite/storage more gently

### DIFF
--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -14,9 +14,7 @@ class graphite::config_apache inherits graphite::params {
 
   package {
     $::graphite::params::apache_pkg:
-      ensure => installed,
-      before => Exec['Chown graphite for web user'],
-      notify => Exec['Chown graphite for web user'];
+      ensure => installed;
   }
 
   package {
@@ -63,8 +61,7 @@ class graphite::config_apache inherits graphite::params {
     ensure     => running,
     enable     => true,
     hasrestart => true,
-    hasstatus  => true,
-    require    => Exec['Chown graphite for web user'],
+    hasstatus  => true;
   }
 
   # Deploy configfiles
@@ -76,7 +73,6 @@ class graphite::config_apache inherits graphite::params {
       mode    => '0644',
       owner   => $::graphite::params::web_user,
       require => [
-        Exec['Chown graphite for web user'],
         Exec['Initial django db creation'],
         Package[$::graphite::params::apache_wsgi_pkg],
       ],
@@ -88,6 +84,7 @@ class graphite::config_apache inherits graphite::params {
       mode    => '0644',
       owner   => $::graphite::params::web_user,
       require => [
+        File['/opt/graphite/storage'],
         File["${::graphite::params::apache_dir}/ports.conf"],
       ],
       notify  => Service[$::graphite::params::apache_service_name];

--- a/manifests/config_gunicorn.pp
+++ b/manifests/config_gunicorn.pp
@@ -14,9 +14,7 @@ class graphite::config_gunicorn inherits graphite::params {
 
     package {
       'gunicorn':
-        ensure => installed,
-        before => Exec['Chown graphite for web user'],
-        notify => Exec['Chown graphite for web user'];
+        ensure => installed;
     }
 
     service { 'gunicorn':
@@ -25,7 +23,8 @@ class graphite::config_gunicorn inherits graphite::params {
       hasrestart => true,
       hasstatus  => false,
       require    => [
-        Exec['Chown graphite for web user'],
+        File['/opt/graphite/storage/run'],
+        File['/opt/graphite/storage/log'],
         Exec['Initial django db creation'],
         Package['gunicorn'],
       ],
@@ -45,9 +44,7 @@ class graphite::config_gunicorn inherits graphite::params {
 
     package {
       'python-gunicorn':
-        ensure => installed,
-        before => Exec['Chown graphite for web user'],
-        notify => Exec['Chown graphite for web user'];
+        ensure => installed;
     }
   } else {
     fail("wsgi/gunicorn-based graphite is not supported on ${::operatingsystem} (only supported on Debian & RedHat)")

--- a/manifests/config_nginx.pp
+++ b/manifests/config_nginx.pp
@@ -18,9 +18,7 @@ class graphite::config_nginx inherits graphite::params {
 
   package {
     'nginx':
-      ensure => installed,
-      before => Exec['Chown graphite for web user'],
-      notify => Exec['Chown graphite for web user'];
+      ensure => installed;
   }
 
   file { '/etc/nginx/sites-enabled/default':
@@ -34,8 +32,7 @@ class graphite::config_nginx inherits graphite::params {
       ensure     => running,
       enable     => true,
       hasrestart => true,
-      hasstatus  => true,
-      require    => Exec['Chown graphite for web user'];
+      hasstatus  => true;
   }
 
   # Ensure that some directories exist first. This is normally handled by the
@@ -68,8 +65,7 @@ class graphite::config_nginx inherits graphite::params {
       content => template('graphite/etc/nginx/sites-available/graphite.erb'),
       require => [
         File['/etc/nginx/sites-available'],
-        Exec['Initial django db creation'],
-        Exec['Chown graphite for web user']
+        Exec['Initial django db creation']
       ],
       notify  => Service['nginx'];
 


### PR DESCRIPTION
Running `chown -R` on /opt/graphite/storage/whisper can take a very long
time on large installations with hundreds of thousands of metrics, and
it will also disrupt carbon-cache write operations if it is running with
a different user than root or web user. So I replaced it with an
explicit list of directories, which should be sufficient.

Also, most requirements on Exec['Chown graphite for web user'] were not
necessary, so I removed them, and replaced the others with requirements
on /opt/graphite/storage.