### PR TITLE
Added dependency on graphite::install to apache::vhost.

### DIFF
--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -37,6 +37,7 @@ class graphite::config_apache inherits graphite::params {
   # Deploy configfiles
 
   apache::vhost { "graphite.${::domain}":
+    require                     => Class['graphite::install'],
     port                        => $::graphite::gr_apache_port,
     servername                  => $::graphite::gr_web_servername,
     docroot                     => '/opt/graphite/webapp',


### PR DESCRIPTION
We are experiencing the following evaluation order problem that also occured as part of issue 163:

https://github.com/echocat/puppet-graphite/issues/163#issuecomment-82185456

I implemented the solution proposed in this subsequent comment and it works for us:

https://github.com/echocat/puppet-graphite/issues/163#issuecomment-82490823

The root cause appears to be a catalog order problem, since we have one machine that flawlessly deploys graphite in the course of the first puppet run, and another one that takes two puppet runs (due to /opt/graphite being unavailable). Having the apache::vhost resource depend on graphite::install fixes things for this particular occurence, but there may well be similar Heisenbugs still in hiding.