### PR TITLE
Add a parameter to enable/disable carbon cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ Default is empty. The group of the user (see gr_user) who runs graphite.
 
 Default is empty. The user who runs graphite. If this is empty carbon runs as the user that invokes it.
 
+#####`gr_enable_carbon_cache`
+
+Default is true. Enable carbon cache.
+
 #####`gr_max_cache_size`
 
 Default is 'inf'. Limits the size of the cache to avoid swapping or becoming CPU bound. Use the value "inf" (infinity) for an unlimited cache size.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,9 @@
 #   The user who runs graphite. If this is empty carbon runs as the user that
 #   invokes it.
 #   Default is empty.
+# [*gr_enable_carbon_cache*]
+#   Enable carbon cache.
+#   Default is true.
 # [*gr_max_cache_size*]
 #   Limit the size of the cache to avoid swapping or becoming CPU bound. Use
 #   the value "inf" (infinity) for an unlimited cache size.
@@ -430,6 +433,7 @@
 class graphite (
   $gr_group                              = '',
   $gr_user                               = '',
+  $gr_enable_carbon_cache                = true,
   $gr_max_cache_size                     = inf,
   $gr_max_updates_per_second             = 500,
   $gr_max_updates_per_second_on_shutdown = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,9 +24,8 @@ class graphite::params {
   $whisper_pkg        = 'whisper'
   $whisper_ver        = '0.9.12'
 
-  $install_prefix      = '/opt/'
-  $enable_carbon_relay = false
-  $nginxconf_dir       = '/etc/nginx/sites-available'
+  $install_prefix     = '/opt/'
+  $nginxconf_dir      = '/etc/nginx/sites-available'
 
   case $::osfamily {
     'Debian': {


### PR DESCRIPTION
This is useful when you want to run carbon-relay/carbon-aggregator alone on a different host.