### PR TITLE
Disable cache in graphite to remedy display errors in grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ apache::vhost { graphite.my.domain:
   ]
 }->
 class { 'graphite':
-  gr_web_server          => 'none',
+  gr_web_server           => 'none',
   gr_disable_webapp_cache => true,
 }
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ apache::vhost { graphite.my.domain:
   ]
 }->
 class { 'graphite':
-  gr_web_server => 'none'
+  gr_web_server          => 'none',
+  gr_disable_webapp_cache => true,
 }
 
 apache::vhost { 'grafana.my.domain':
@@ -775,6 +776,10 @@ Default is '0.9.12' (string) The version of the whisper package that should be i
 
 Default is true (Bool). Should packages be installed via pip
 
+#####`gr_disable_webapp_cache`
+
+Default is false (Bool). Should the caching of the webapp be disabled. This helps with some
+display issues in grafana.
 
 ##Requirements
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -421,6 +421,10 @@
 # [*gr_pip_install*]
 #   Boolean. Should the package be installed via pip
 #   Default: true
+#[*gr_disable_webapp_cache*]
+#   Boolean. Should the caching of the webapp be disabled. This helps with some
+#   display issues in grafana.
+#   Default: false
 #
 # === Examples
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -604,6 +604,7 @@ class graphite (
   $gr_whisper_pkg                        = $::graphite::params::whisper_pkg,
   $gr_whisper_ver                        = $::graphite::params::whisper_ver,
   $gr_pip_install                        = true,
+  $gr_disable_webapp_cache               = false,
 ) inherits graphite::params {
   # Validation of input variables.
   # TODO - validate all the things

--- a/templates/opt/graphite/webapp/graphite/local_settings.py.erb
+++ b/templates/opt/graphite/webapp/graphite/local_settings.py.erb
@@ -51,6 +51,7 @@ MEMCACHE_HOSTS = ['<%= scope.lookupvar('graphite::gr_memcache_hosts').join("','"
 
 #DEFAULT_CACHE_DURATION = 60 # Cache images and data for 1 minute
 
+<% if scope.lookupvar('graphite::gr_disable_webapp_cache') -%>
 # disable cache to reduce graph errors
 # https://github.com/graphite-project/graphite-web/issues/576#issuecomment-36246428
 CACHES = {
@@ -59,6 +60,7 @@ CACHES = {
     },
 }
 
+<% end -%>
 
 #####################################
 # Filesystem Paths #

--- a/templates/opt/graphite/webapp/graphite/local_settings.py.erb
+++ b/templates/opt/graphite/webapp/graphite/local_settings.py.erb
@@ -51,6 +51,14 @@ MEMCACHE_HOSTS = ['<%= scope.lookupvar('graphite::gr_memcache_hosts').join("','"
 
 #DEFAULT_CACHE_DURATION = 60 # Cache images and data for 1 minute
 
+# disable cache to reduce graph errors
+# https://github.com/graphite-project/graphite-web/issues/576#issuecomment-36246428
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    },
+}
+
 
 #####################################
 # Filesystem Paths #


### PR DESCRIPTION
I use grafana as frontend for graphite. Sometimes, the graphs would not update.

I found that I had to disable the cache to reduce graph errors
https://github.com/graphite-project/graphite-web/issues/576#issuecomment-36246428

If needed, I can make this configurable. In order to do this the "right way", I would like some feedback how and when the cache is used and configured.