### PR TITLE
Setting a custom gr_django_db_name path doesn't set correct permissions

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -101,7 +101,7 @@ class graphite::config inherits graphite::params {
 
   # Lets ensure graphite.db owner is the same as gr_web_user
   file {
-    '/opt/graphite/storage/graphite.db':
+    $::graphite::gr_django_db_name:
       ensure  => file,
       group   => $::graphite::gr_web_group,
       mode    => '0644',


### PR DESCRIPTION
The database path for graphite.db can be customised, but the permissions
of the webserver user and group don't apply to that custom path, as
it's currently hardcoded to /opt/graphite/storage/graphite.db