### PR TITLE
Carbon Cache init.d discrepancy

### DIFF
--- a/templates/etc/init.d/RedHat/carbon-cache.erb
+++ b/templates/etc/init.d/RedHat/carbon-cache.erb
@@ -112,6 +112,7 @@ restart() {
         retval=$?
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         echo -n $"Starting carbon-${CARBON_DAEMON}:${INSTANCE}..."
+        sleep 1
         if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
             echo_success


### PR DESCRIPTION
In the RedHat version of the carbon cache init.d file, there is a discrepancy between the start() function and the "start()" functionality in the reset() function. In the former, the code executes a `sleep 1` before checking the status variable of the service; this does not happen in the latter. As a result, the puppet provisioning fails because it does not wait for the carbon-cache service to start and assumes that the startup has failed.