### PR TITLE
Proxy Exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,20 @@ Template to use for Apache vhost config. Default is 'graphite/etc/apache2/sites-
 Boolean to enable configuration parts for Apache 2.4 instead of 2.2
 Default is false/true (autodected. see params.pp)
 
+#####`gr_apache_noproxy`
+
+Optional setting to disable proxying of requests. When set, will supply a value to 'NoProxy'.
+```
+{
+  gr_apache_noproxy   => "0.0.0.0/0"
+}
+```
+Will insert:
+```
+  NoProxy 0.0.0.0/0
+```
+In the /etc/apache2/conf.d/graphite.conf file.
+
 #####`gr_django_1_4_or_less`
 
 Default is false (boolean). Django settings style.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -516,6 +516,7 @@ class graphite (
   $gr_apache_port_https                   = 443,
   $gr_apache_conf_template                = 'graphite/etc/apache2/sites-available/graphite.conf.erb',
   $gr_apache_24                           = $::graphite::params::apache_24,
+  $gr_apache_noproxy                      = undef,
   $gr_django_1_4_or_less                  = false,
   $gr_django_db_engine                    = 'django.db.backends.sqlite3',
   $gr_django_db_name                      = '/opt/graphite/storage/graphite.db',

--- a/templates/etc/apache2/sites-available/graphite.conf.erb
+++ b/templates/etc/apache2/sites-available/graphite.conf.erb
@@ -20,6 +20,7 @@ WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefi
 <VirtualHost *:<%= scope.lookupvar('graphite::gr_apache_port') %>>
 	ServerName <%= scope.lookupvar('graphite::gr_web_servername') %>
 	DocumentRoot "/opt/graphite/webapp"
+<% if scope.lookupvar('graphite::gr_apache_noproxy') %>	NoProxy <%= scope.lookupvar('graphite::gr_apache_noproxy') %><% end %>
 
 	ErrorLog /opt/graphite/storage/error.log
 	CustomLog /opt/graphite/storage/access.log common


### PR DESCRIPTION
There was no apparent functionality for disabling proxying for graphite. This pull will create an optional variable that the user can enable to disable proxying (such as mod_cluster).