### PR TITLE
Disable default Apache webpage on Debian 7.8

### DIFF
--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -39,7 +39,7 @@ class graphite::config_apache inherits graphite::params {
       exec { 'Disable default apache site':
         command => 'a2dissite 000-default',
         notify  => Service[$::graphite::params::apache_service_name],
-        onlyif  => 'test -f /etc/apache2/sites-enabled/000-default.conf',
+        onlyif  => 'test -f /etc/apache2/sites-enabled/000-default -o -f /etc/apache2/sites-enabled/000-default.conf',
         require => Package[$::graphite::params::apache_wsgi_pkg],
       }
     }


### PR DESCRIPTION
1. Use this puppet module on a Debian 7.8
1. Point your browser to the machine
1. I expect to see the Graphite web interface
1. Instead, I see the default apache2 webpage

Cause:
*config_apache.pp* did not execute the step 'Disable default apache site', because the symlink to the default apache webpage in */etc/apache2/sites-enabled* is called *000-default*, instead of *000-default.conf*

The file is *000-default* is put there by apache2.2-common, version: 2.2.22-13+deb7u4.

Fix: 
Test for either 000-default or 000-default.conf with `test -f /etc/apache2/sites-enabled/000-default -o -f /etc/apache2/sites-enabled/000-default.conf`