### PR TITLE
Fix log rotate for puppet 4

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -213,7 +213,7 @@ class graphite::config inherits graphite::params {
   # configure logrotate
   logrotate::rule { 'carbon':
     path          => '/opt/graphite/storage/log/carbon-cache/',
-    rotate        => 30,
+    rotate        => '30',
     rotate_every  => 'day',
     compress      => true,
     delaycompress => true,


### PR DESCRIPTION
The Logrotate module doesn't play nicely with puppet 4 - it complains that `30` is not an integer (when it clearly is).

This changes `30` to `'30'` (making it a string), which keeps the logrotate module happy.