### PR TITLE
Support configuring WHISPER_AUTOFLUSH in carbon.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,10 @@ Default is empty array. Allow multiple additional aggregator instances. (beside 
 
 Example: see gr_cache_instances
 
+#####`gr_whisper_autoflush`
+
+Default is false. Set autoflush for whisper
+
 #####`gr_whisper_lock_writes`
 
 Default is false. Set lock writes for whisper

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -386,6 +386,9 @@
 #   Allow multiple additional aggregator instances. (beside the default one)
 #   Default = []
 #   Example: see gr_cache_instances
+# [*gr_whisper_autoflush*]
+#   Set autoflush for whisper
+#   Default is false
 # [*gr_whisper_lock_writes*]
 #   Set lock writes for whisper
 #   Default is false
@@ -622,6 +625,7 @@ class graphite (
   $gr_cache_instances                     = [],
   $gr_relay_instances                     = [],
   $gr_aggregator_instances                = [],
+  $gr_whisper_autoflush                   = 'False',
   $gr_whisper_lock_writes                 = 'False',
   $gr_whisper_fallocate_create            = 'False',
   $gr_log_cache_performance               = 'False',

--- a/templates/opt/graphite/conf/carbon.conf.erb
+++ b/templates/opt/graphite/conf/carbon.conf.erb
@@ -137,7 +137,7 @@ CACHE_WRITE_STRATEGY = <%= scope.lookupvar('graphite::gr_cache_write_strategy') 
 # On some systems it is desirable for whisper to write synchronously.
 # Set this option to True if you'd like to try this. Basically it will
 # shift the onus of buffering writes from the kernel into carbon's cache.
-WHISPER_AUTOFLUSH = False
+WHISPER_AUTOFLUSH = <%= scope.lookupvar('graphite::gr_whisper_autoflush') %>
 
 # By default new Whisper files are created pre-allocated with the data region
 # filled with zeros to prevent fragmentation and speed up contiguous reads and


### PR DESCRIPTION
Following the same pattern used to configure `WHISPER_FALLOCATE_CREATE` I've added support for configuring `WHISPER_AUTOFLUSH` too as setting this to `True` has proved beneficial in our scenarios.