### PR TITLE
Only install gcc when installing python-devel

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,10 +24,11 @@ class graphite::install inherits graphite::params {
   }
   $gr_pkg_require = $::graphite::gr_pip_install ? {
     default => undef,
-    true    => Package[
-      $::graphite::params::graphitepkgs,
-      $::graphite::params::python_pip_pkg,
-      $::graphite::params::python_dev_pkg],
+    true    => [
+      Package[$::graphite::params::graphitepkgs],
+      Package[$::graphite::params::python_pip_pkg],
+      Package[$::graphite::params::python_dev_pkg],
+    ],
   }
 
   # variables to workaround unusual graphite install target:
@@ -95,10 +96,10 @@ class graphite::install inherits graphite::params {
 
     # using the pip package provider requires python-pip
     # also install python headers and libs for pip
-    ensure_packages([
+    ensure_packages(flatten([
       $::graphite::params::python_pip_pkg,
       $::graphite::params::python_dev_pkg,
-    ])
+    ]))
 
     # hack unusual graphite install target
     create_resources('file',{

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -84,46 +84,32 @@ class graphite::params {
       $web_group = 'apache'
       $web_user = 'apache'
 
-      $python_dev_pkg = 'python-devel'
+      $python_dev_pkg = ['python-devel','gcc']
+      $common_os_pkgs = [
+        'MySQL-python',
+        'bitmap',
+        'bitmap-fonts-compat',
+        'pyOpenSSL',
+        'pycairo',
+        'python-crypto',
+        'python-ldap',
+        'python-memcached',
+        'python-psycopg2',
+        'python-zope-interface',
+      ]
 
       # see https://github.com/graphite-project/carbon/issues/86
       case $::operatingsystemrelease {
         /^6\.\d+$/: {
           $apache_24    = false
           $django_pkg = 'Django14'
-          $graphitepkgs = [
-            'MySQL-python',
-            'bitmap',
-            'bitmap-fonts-compat',
-            'gcc',
-            'pyOpenSSL',
-            'pycairo',
-            'python-crypto',
-            'python-ldap',
-            'python-memcached',
-            'python-psycopg2',
-            'python-sqlite2',
-            'python-zope-interface',
-          ]
+          $graphitepkgs = union($common_os_pkgs,['python-sqlite2'])
         }
 
         /^7\.\d+/: {
           $apache_24    = true
           $django_pkg = 'python-django'
-          $graphitepkgs = [
-            'MySQL-python',
-            'bitmap',
-            'bitmap-fonts-compat',
-            'gcc',
-            'pyOpenSSL',
-            'pycairo',
-            'python-crypto',
-            'python-ldap',
-            'python-memcached',
-            'python-psycopg2',
-            'python-sqlite3dbm',
-            'python-zope-interface',
-          ]
+          $graphitepkgs = union($common_os_pkgs,['python-sqlite3dbm'])
         }
 
         default: {

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -21,6 +21,7 @@ describe 'graphite::install', :type => 'class' do
 
   shared_context 'supported platforms' do
     it { should contain_class('graphite::params') }
+    it { should contain_package('python-pip').with_provider(nil) }
     it { should contain_package('python-ldap').with_provider(nil) }
     it { should contain_package('python-psycopg2').with_provider(nil) }
 
@@ -39,6 +40,10 @@ describe 'graphite::install', :type => 'class' do
     ].each do |pkg|
       it { should contain_package(pkg).with_provider(nil).that_requires(nil) }
     end
+    it { should_not contain_package('gcc') }
+    it { should_not contain_package('python-pip') }
+    it { should_not contain_package('python-dev') }
+    it { should_not contain_package('python-devel') }
     it { should_not contain_file('carbon_hack') }
     it { should_not contain_file('gweb_hack')   }
   end
@@ -53,10 +58,11 @@ describe 'graphite::install', :type => 'class' do
     it { should contain_package('carbon').with_provider(
       'pip').that_requires('Package[gcc]') }
 
+    it { should contain_package('python-devel').with_provider(nil) }
+    it { should contain_package('gcc').with_provider(nil) }
     it { should contain_package('MySQL-python').with_provider(nil) }
     it { should contain_package('bitmap').with_provider(nil) }
     it { should contain_package('bitmap-fonts-compat').with_provider(nil) }
-    it { should contain_package('gcc').with_provider(nil) }
     it { should contain_package('pyOpenSSL').with_provider(nil) }
     it { should contain_package('pycairo').with_provider(nil) }
     it { should contain_package('python-crypto').with_provider(nil) }


### PR DESCRIPTION
With the recent re-factoring of `graphite::install` this is pretty easy.  Per discussion at https://github.com/echocat/puppet-graphite/issues/179