### PR TITLE
Fix false negative RHEL7 not supported error

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,7 +13,7 @@ class graphite::install inherits graphite::params {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
   if $::graphite::gr_pip_install and $::osfamily == 'RedHat' {
-    validate_re($::operatingsystemrelease,'^[6-7]\.\d+$',
+    validate_re($::operatingsystemrelease,'^[6-7]\.\d+',
     "Unsupported RedHat release: '${::operatingsystemrelease}'")
   }
 


### PR DESCRIPTION
This patch fixes:
```
DEBUG [c71e1341]    [1;31mError: Could not retrieve catalog from remote server: Error 400 on SERVER: Unsupported RedHat release: '7.1.1503' at /etc/puppet/environments/development/modules/graphite/manifests/install.pp:16 on node graphite.company.com[0m
DEBUG [c71e1341]    [1;31mWarning: Not using cache on failed catalog[0m
DEBUG [c71e1341]    [1;31mError: Could not retrieve catalog; skipping run[0m
```

Graphite::install used to verify RHEL6 style version numbers (6.x) while RHEL7 versions include build numbers (7.x.y).