### PR TITLE
Compatibility with future parser

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -619,7 +619,6 @@ class graphite (
   $gr_use_remote_user_auth                = 'False',
   $gr_remote_user_header_name             = undef,
   $gr_local_data_dir                      = '/opt/graphite/storage/whisper',
-  $gr_rrd_dir                             = '/opt/graphite/storage/rrd',
   $gunicorn_arg_timeout                   = 30,
   $gunicorn_bind                          = 'unix:/var/run/graphite.sock',
   $gunicorn_workers                       = 2,

--- a/templates/etc/nginx/sites-available/graphite.erb
+++ b/templates/etc/nginx/sites-available/graphite.erb
@@ -22,7 +22,7 @@ server {
 	# proxy remaining requests to graphite
 
 	location / {
-<% unless scope.lookupvar('graphite::nginx_htpasswd') == :undef -%>
+<% unless [:undef, nil].include? scope.lookupvar('graphite::nginx_htpasswd') -%>
 		auth_basic "You shall not pass";
 		auth_basic_user_file /etc/nginx/graphite-htpasswd;
 <% end %>

--- a/templates/opt/graphite/webapp/graphite/local_settings.py.erb
+++ b/templates/opt/graphite/webapp/graphite/local_settings.py.erb
@@ -86,7 +86,7 @@ CACHES = {
 ## Data directories
 # NOTE: If any directory is unreadable in DATA_DIRS it will break metric browsing
 WHISPER_DIR = '<%= scope.lookupvar('graphite::gr_local_data_dir') %>'
-RRD_DIR = '<%= scope.lookupvar('graphite::gr_rrd_dir') %>'
+#RRD_DIR = '/opt/graphite/storage/rrd'
 #DATA_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables
 #LOG_DIR = '/opt/graphite/storage/log/webapp'
 #INDEX_FILE = '/opt/graphite/storage/index'  # Search index file


### PR DESCRIPTION
Similar to #112, this adds future parser compatibility. Without this,
the nginx config thinks there's an htpasswd set up even when the
variable is undef.