### PR TITLE
Compatibility with future parser

### DIFF
--- a/templates/etc/nginx/sites-available/graphite.erb
+++ b/templates/etc/nginx/sites-available/graphite.erb
@@ -22,7 +22,7 @@ server {
 	# proxy remaining requests to graphite
 
 	location / {
-<% unless scope.lookupvar('graphite::nginx_htpasswd') == :undef -%>
+<% unless [:undef, nil].include? scope.lookupvar('graphite::nginx_htpasswd') -%>
 		auth_basic "You shall not pass";
 		auth_basic_user_file /etc/nginx/graphite-htpasswd;
 <% end %>


### PR DESCRIPTION
Similar to #112, this adds future parser compatibility. Without this,
the nginx config thinks there's an htpasswd set up even when the
variable is undef.