### PR TITLE
Add new gr_manage_python_packages option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,16 @@ Additionally, the Django package is normally installed from a system package, bu
   }
 ```
 
+####Managing system pip and Python development packages
+If `gr_pip_install` is set to `true`, both `python-pip` and Python development packages will need to be installed. If you want to manage those packages separately, set `gr_manage_python_packages` to `false`.
+
+```puppet
+  class { '::graphite':
+    gr_pip_install            => true,
+    gr_manage_python_packages => false,
+  }
+```
+
 ##Usage
 
 ####Class: `graphite`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -454,6 +454,9 @@
 # [*gr_pip_install*]
 #   Boolean. Should the package be installed via pip
 #   Default: true
+# [*gr_manage_python_packages*]
+#   Boolean. Should the pip and python dev packages be managed by this module.
+#   Default: true
 # [*gr_disable_webapp_cache*]
 #   Boolean. Should the caching of the webapp be disabled. This helps with some
 #   display issues in grafana.
@@ -650,6 +653,7 @@ class graphite (
   $gr_django_ver                          = $::graphite::params::django_ver,
   $gr_django_provider                     = $::graphite::params::django_provider,
   $gr_pip_install                         = true,
+  $gr_manage_python_packages              = true,
   $gr_disable_webapp_cache                = false,
   $gr_carbonlink_query_bulk               = undef,
   $gr_carbonlink_hosts_timeout            = '1.0',
@@ -671,6 +675,7 @@ class graphite (
   validate_bool($manage_ca_certificate)
   validate_bool($gr_use_ldap)
   validate_bool($gr_pip_install)
+  validate_bool($gr_manage_python_packages)
   validate_bool($gr_disable_webapp_cache)
 
   # validate integers

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -96,10 +96,12 @@ class graphite::install inherits graphite::params {
 
     # using the pip package provider requires python-pip
     # also install python headers and libs for pip
-    ensure_packages(flatten([
-      $::graphite::params::python_pip_pkg,
-      $::graphite::params::python_dev_pkg,
-    ]))
+    if $::graphite::gr_manage_python_packages {
+      ensure_packages(flatten([
+        $::graphite::params::python_pip_pkg,
+        $::graphite::params::python_dev_pkg,
+      ]))
+    }
 
     # hack unusual graphite install target
     create_resources('file',{


### PR DESCRIPTION
Sometimes you want to manage the installation of `python-pip` and
`python-devel` somewhere else (for example, if using the
stankevich/python module). This option allows you to turn off the
installation of these packages to avoid duplicate resource issues.