### PR TITLE
Nginx/Gunicorn support for RedHat and other small things

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,19 @@ The storage aggregation rules.
 
 #####`gr_web_server`
 
-Default is 'apache'. The web server to use. Valid values are 'apache', 'nginx', 'wsgionly' or 'none'. 'nginx' is only supported on Debian-like systems. And 'none' means that you will manage the webserver yourself.
+Default is 'apache'. The web server to configure. Valid values are 'apache', 'nginx', 'wsgionly' or 'none'. 
+
+Apache is configured with mod_wsgi, nginx is configured with gunicorn. 'wsgionly' configures only gunicorn.
+
+The value 'none' means that you will manage the webserver yourself.
+
+#####`gr_web_server_port`
+
+Default is 80. The HTTP port which the web server will use. Only used for $gr_web_server => 'apache' or 'nginx'.
+
+#####`gr_web_server_port_https`
+
+Default is 443. The HTTPS port which the web server will use. Only used for $gr_web_server => 'apache'.
 
 #####`gr_web_servername`
 
@@ -429,19 +441,11 @@ Path to SSL dir containing keys and certs. Default is undef.
 
 #####`gr_web_group`
 
-Default is undef. Group name to chgrp the files that will served by webserver.  Use only with gr_web_server => 'wsgionly' or 'none'.
+Group name to chgrp the files that will served by webserver. Only necessary for gr_web_server => 'wsgionly' or 'none'.
 
 #####`gr_web_user`
 
-Default is undef. Username to chown the files that will served by webserver.  Use only with gr_web_server => 'wsgionly' or 'none'.
-
-#####`gr_apache_port`
-
-Default is 80. The HTTP port apache will use.
-
-#####`gr_apache_port_https`
-
-Default is 443. The HTTPS port apache will use.
+Username to chown the files that will served by webserver. Only necessary for gr_web_server => 'wsgionly' or 'none'.
 
 #####`gr_apache_conf_template`
 

--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ ones set for the principal instance.
 So in this case you would have 3 cache instances, the first one is `cache` (you can refer to it as `cache:a` too), `cache:b` and `cache:c`. cache:a will listen on ports 2003, 2004 and 7002 for line, pickle and query respectively. But, cache:b will do it on ports 2103, 2104, and 7102, and cache:c on 2203, 2204 and 7202. All other parameters from cache:a will be inherited by cache:b and c.
 
 ###Installing with something other than pip and specifying package names and versions
-If you need to install via something other pip, an internal apt repo with fpm converted packages for instance, you can set `gr_pip_install` to false.
-If you're doing this you'll most likely have to override the default package names and versions as well. 
+If you need to install via something other than pip, an internal apt repo with fpm converted packages for instance, you can set `gr_pip_install` to false.
+If you're doing this you'll most likely have to override the default package names and versions as well.
 ```puppet
   class { '::graphite':
     gr_pip_install        => false,
@@ -869,7 +869,7 @@ On Redhat distributions you need the EPEL or RPMforge repository, because Graphi
 
 ##Limitations
 
-This module is tested on CentOS 6.5 and Debian 7 (Wheezy) and should also run without problems on
+This module is tested on CentOS 6.5 and Debian 7 (Wheezy) and should also run on
 
 * RHEL/CentOS/Scientific 6+
 * Debian 6+
@@ -878,8 +878,17 @@ This module is tested on CentOS 6.5 and Debian 7 (Wheezy) and should also run wi
 Most settings of Graphite can be set by parameters. So their can be special configurations for you. In this case you should edit
 the file `templates/opt/graphite/webapp/graphite/local_settings.py.erb`.
 
-The nginx configs are only supported on Debian based systems at the moment.
+###Compatibility Notes
+* There is currently an [open ticket](https://tickets.puppetlabs.com/browse/PUP-3829) with Puppet about broken pip support in CentOS 6/7. The
+workaround for this bug is to create a symlink from `/usr/bin/pip-python` (which doesn't exist) to `/usr/bin/pip` (which does).
+* CentOS 7's default `nginx.conf` includes a `server` section listening on port 80. Thus, it is not possible to set up graphite without modifying 
+the package-provided configuration file. You will have to either manually remove the `server` section, or provide a `gr_web_server_port` other
+than port 80.
+* nginx/gunicorn requires a `systemctl restart gunicorn` after installing on Ubuntu 15.10
+* SELinux must be disabled
 
 ##Contributing
 
 Echocat modules are open projects. So if you want to make this module even better, you can contribute to this module on [Github](https://github.com/echocat/puppet-graphite).
+
+Make sure to read the repository's `DEVELOP.md` file first.

--- a/files/fix-graphite-race-condition.py
+++ b/files/fix-graphite-race-condition.py
@@ -1,0 +1,18 @@
+import sys
+sys.path.append('/opt/graphite/webapp')
+from django.contrib.auth.models import User
+from graphite.account.models import Profile
+from graphite.logger import log
+try:
+  defaultUser = User.objects.get(username='default')
+except User.DoesNotExist:
+  randomPassword = User.objects.make_random_password(length=16)
+  defaultUser = User.objects.create_user('default','default@localhost.localdomain',randomPassword)
+  defaultUser.save()
+
+try:
+  defaultProfile = Profile.objects.get(user=defaultUser)
+except Profile.DoesNotExist:
+  defaultProfile = Profile(user=defaultUser)
+  defaultProfile.save()
+

--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -61,6 +61,29 @@ class graphite::config_apache inherits graphite::params {
     }
   }
 
+  # fix graphite's race condition on start
+  # if the exec fails, assume we're using a version of graphite that doesn't need it
+  file { '/tmp/fix-graphite-race-condition.py':
+    ensure => file,
+    source => 'puppet:///modules/graphite/fix-graphite-race-condition.py',
+    mode   => '0755',
+  }
+  exec { 'fix graphite race condition':
+    command     => 'python /tmp/fix-graphite-race-condition.py',
+    cwd         => '/opt/graphite/webapp',
+    environment => 'DJANGO_SETTINGS_MODULE=graphite.settings',
+    user        => $graphite::config::gr_web_user_REAL,
+    logoutput   => true,
+    group       => $graphite::config::gr_web_group_REAL,
+    returns     => [0, 1],
+    require     => [
+      File['/tmp/fix-graphite-race-condition.py'],
+      Exec['Initial django db creation'],
+      Service['carbon-cache'],
+    ],
+    before      => Service[$::graphite::params::apache_service_name],
+  }
+
   service { $::graphite::params::apache_service_name:
     ensure     => running,
     enable     => true,
@@ -73,9 +96,9 @@ class graphite::config_apache inherits graphite::params {
     "${::graphite::params::apache_dir}/ports.conf":
       ensure  => file,
       content => template('graphite/etc/apache2/ports.conf.erb'),
-      group   => $::graphite::gr_web_group_REAL,
+      group   => $::graphite::config::gr_web_group_REAL,
       mode    => '0644',
-      owner   => $::graphite::gr_web_user_REAL,
+      owner   => $::graphite::config::gr_web_user_REAL,
       require => [
         Exec['Initial django db creation'],
         Package[$::graphite::params::apache_wsgi_pkg],
@@ -84,9 +107,9 @@ class graphite::config_apache inherits graphite::params {
     "${::graphite::params::apacheconf_dir}/graphite.conf":
       ensure  => file,
       content => template($::graphite::gr_apache_conf_template),
-      group   => $::graphite::gr_web_group_REAL,
+      group   => $::graphite::config::gr_web_group_REAL,
       mode    => '0644',
-      owner   => $::graphite::gr_web_user_REAL,
+      owner   => $::graphite::config::gr_web_user_REAL,
       require => [
         File['/opt/graphite/storage'],
         File["${::graphite::params::apache_dir}/ports.conf"],

--- a/manifests/config_gunicorn.pp
+++ b/manifests/config_gunicorn.pp
@@ -11,42 +11,126 @@ class graphite::config_gunicorn inherits graphite::params {
   Exec { path => '/bin:/usr/bin:/usr/sbin' }
 
   if $::osfamily == 'Debian' {
+    $package_name = 'gunicorn'
 
-    package {
-      'gunicorn':
-        ensure => installed;
+  } elsif $::osfamily == 'RedHat' {
+    $package_name = 'python-gunicorn'
+
+  } else {
+    fail("wsgi/gunicorn-based graphite is not supported on ${::operatingsystem} (only supported on Debian & RedHat)")
+  }
+
+  if $::service_provider == 'systemd' or ($::service_provider == 'debian' and $::operatingsystemmajrelease == '8') {
+    
+    file { '/etc/systemd/system/gunicorn.service':
+      ensure  => file,
+      content => template('graphite/etc/systemd/gunicorn.service.erb'),
+      mode    => '0644',
     }
 
-    service { 'gunicorn':
-      ensure     => running,
-      enable     => true,
-      hasrestart => true,
-      hasstatus  => false,
-      require    => [
-        File['/opt/graphite/storage/run'],
-        File['/opt/graphite/storage/log'],
-        Exec['Initial django db creation'],
-        Package['gunicorn'],
+    file { '/etc/systemd/system/gunicorn.socket':
+      ensure  => file,
+      content => template('graphite/etc/systemd/gunicorn.socket.erb'),
+      mode    => '0755',
+    }
+
+    file { '/etc/tmpfiles.d/gunicorn.conf':
+      ensure  => file,
+      content => template('graphite/etc/tmpfiles.d/gunicorn.conf.erb'),
+      mode    => '0644',
+    }
+
+    exec { 'gunicorn-reload-systemd':
+      command => 'systemctl daemon-reload',
+      path    => ['/usr/bin', '/usr/sbin', '/bin', '/sbin'],
+      require => [
+        File['/etc/systemd/system/gunicorn.service'],
+        File['/etc/systemd/system/gunicorn.socket'],
+        File['/etc/tmpfiles.d/gunicorn.conf'],
       ],
-      subscribe  => File['/opt/graphite/webapp/graphite/local_settings.py'],
+      before  => Service['gunicorn']
+    }
+    # These next two are needed for Debian for some reason
+    ->
+    exec { 'stop gunicorn-socket':
+      command => 'systemctl stop gunicorn.socket',
+      path    => ['/usr/bin', '/usr/sbin', '/bin', '/sbin'],
+      before  => Service['gunicorn']
+    }
+    ->
+    exec { 'start gunicorn-socket':
+      command => 'systemctl start gunicorn.socket',
+      path    => ['/usr/bin', '/usr/sbin', '/bin', '/sbin'],
+      before  => Service['gunicorn']
     }
 
-    # Deploy configfiles
+  } elsif $::service_provider == 'redhat' {
 
+    file { '/etc/init.d/gunicorn':
+      ensure  => file,
+      content => template('graphite/etc/init.d/RedHat/gunicorn.erb'),
+      mode    => '0755',
+    }
+
+  }
+
+  file { '/opt/graphite/webapp/graphite/wsgi.py':
+    ensure => link,
+    target => '/opt/graphite/conf/graphite.wsgi',
+    before => Service['gunicorn'],
+  }
+
+  # fix graphite's race condition on start
+  # if the exec fails, assume we're using a version of graphite that doesn't need it
+  if $graphite::gunicorn_workers > 1 {
+    file { '/tmp/fix-graphite-race-condition.py':
+      ensure => file,
+      source => 'puppet:///modules/graphite/fix-graphite-race-condition.py',
+      mode   => '0755',
+    }
+    exec { 'fix graphite race condition':
+      command     => 'python /tmp/fix-graphite-race-condition.py',
+      cwd         => '/opt/graphite/webapp',
+      environment => 'DJANGO_SETTINGS_MODULE=graphite.settings',
+      user        => $graphite::gr_web_user_REAL,
+      logoutput   => true,
+      group       => $graphite::gr_web_group_REAL,
+      require     => [
+        File['/tmp/fix-graphite-race-condition.py'],
+        Exec['Initial django db creation'],
+        Service['carbon-cache'],
+      ],
+      before      => Service['gunicorn'],
+    }
+  }
+
+  package {
+    $package_name:
+      ensure => installed;
+  }
+
+  service { 'gunicorn':
+    ensure     => running,
+    enable     => true,
+    hasrestart => true,
+    hasstatus  => false,
+    require    => [
+      File['/opt/graphite/storage/run'],
+      File['/opt/graphite/storage/log'],
+      Exec['Initial django db creation'],
+      Package[$package_name],
+    ],
+    subscribe  => File['/opt/graphite/webapp/graphite/local_settings.py'],
+  }
+
+  # Deploy configfiles
+  if $::osfamily == 'Debian' {
     file { '/etc/gunicorn.d/graphite':
       ensure  => file,
       content => template('graphite/etc/gunicorn.d/graphite.erb'),
       mode    => '0644',
-      notify  => Service['gunicorn'],
-      require => Package['gunicorn'],
+      before  => Service['gunicorn'],
+      require => Package[$package_name],
     }
-  } elsif $::osfamily == 'RedHat' {
-
-    package {
-      'python-gunicorn':
-        ensure => installed;
-    }
-  } else {
-    fail("wsgi/gunicorn-based graphite is not supported on ${::operatingsystem} (only supported on Debian & RedHat)")
   }
 }

--- a/manifests/config_nginx.pp
+++ b/manifests/config_nginx.pp
@@ -17,38 +17,9 @@ class graphite::config_nginx inherits graphite::params {
       ensure => installed;
   }
 
-  # Remove default config file, but only when it makes sense
-  if ($::graphite::gr_web_server_port == 80 and $::graphite::gr_web_server_remove_default == undef) or ($::graphite::gr_web_server_remove_default == true) {
-    case $::osfamily {
-      'Debian': {
-        file { '/etc/nginx/sites-enabled/default':
-          ensure  => absent,
-          require => Package['nginx'],
-          notify  => Service['nginx'];
-        }
-      }
-      'RedHat': {
-        file { '/etc/nginx/conf.d/default.conf':
-          ensure  => absent,
-          require => Package['nginx'],
-          notify  => Service['nginx'],
-        }
-      }
-    }
-  }
-
-  service {
-    'nginx':
-      ensure     => running,
-      enable     => true,
-      hasrestart => true,
-      hasstatus  => true;
-  }
-
   # Ensure that some directories exist first. This is normally handled by the
   # package, but if we uninstall and reinstall nginx and delete /etc/nginx.
   # By default the package manager won't replace the directory.
-
   file {
     '/etc/nginx':
       ensure  => directory,
@@ -56,8 +27,13 @@ class graphite::config_nginx inherits graphite::params {
       require => Package['nginx'];
   }
 
+  # Remove default config file, but only when it makes sense
   case $::osfamily {
     'Debian': {
+
+      # Ensure that some directories exist first. This is normally handled by the
+      # package, but if we uninstall and reinstall nginx and delete /etc/nginx.
+      # By default the package manager won't replace the directory.
       file {
         '/etc/nginx/sites-available':
           ensure  => directory,
@@ -69,22 +45,8 @@ class graphite::config_nginx inherits graphite::params {
           mode    => '0755',
           require => File['/etc/nginx'];
       }
-    }
-    'RedHat': {
-      file {
-        '/etc/nginx/conf.d':
-          ensure  => directory,
-          mode    => '0755',
-          require => File['/etc/nginx'];
-      }
-    }
-  }
 
-
-  # Deploy configfiles
-
-  case $::osfamily {
-    'Debian': {
+      # Deploy configfiles
       file {
         '/etc/nginx/sites-available/graphite':
           ensure  => file,
@@ -105,8 +67,32 @@ class graphite::config_nginx inherits graphite::params {
           ],
           notify  => Service['nginx'];
       }
-    }
+
+      # Remove default config file, but only when it makes sense
+      if ($::graphite::gr_web_server_port == 80 and $::graphite::gr_web_server_remove_default == undef) or ($::graphite::gr_web_server_remove_default == true) {
+        file { '/etc/nginx/sites-enabled/default':
+          ensure  => absent,
+          require => Package['nginx'],
+          notify  => Service['nginx'];
+        }
+      }
+
+    } # Finish Debian config
+    
+    # Config for RedHat
     'RedHat': {
+      
+      # Ensure that some directories exist first. This is normally handled by the
+      # package, but if we uninstall and reinstall nginx and delete /etc/nginx.
+      # By default the package manager won't replace the directory.
+      file {
+        '/etc/nginx/conf.d':
+          ensure  => directory,
+          mode    => '0755',
+          require => File['/etc/nginx'];
+      }
+
+      # Deploy config file for site
       file {
         '/etc/nginx/conf.d/graphite.conf':
           ensure  => file,
@@ -118,7 +104,30 @@ class graphite::config_nginx inherits graphite::params {
           ],
           notify  => Service['nginx'];
       }
+
+      # Remove default config file, but only when it makes sense
+      if ($::graphite::gr_web_server_port == 80 and $::graphite::gr_web_server_remove_default == undef) or ($::graphite::gr_web_server_remove_default == true) {
+        file { '/etc/nginx/conf.d/default.conf':
+          ensure  => absent,
+          require => Package['nginx'],
+          notify  => Service['nginx'],
+        }
+      }
+
     }
+
+    default: {
+      fail('Only Debian and RedHat-like systems are supported.')
+    }
+  
+  }
+
+  service {
+    'nginx':
+      ensure     => running,
+      enable     => true,
+      hasrestart => true,
+      hasstatus  => true;
   }
 
 
@@ -132,7 +141,7 @@ class graphite::config_nginx inherits graphite::params {
     '/etc/nginx/graphite-htpasswd':
       ensure  => $nginx_htpasswd_file_presence,
       mode    => '0400',
-      owner   => $::graphite::gr_web_user_REAL,
+      owner   => $::graphite::config::gr_web_user_REAL,
       content => $::graphite::nginx_htpasswd,
       require => Package['nginx'],
       notify  => Service['nginx'];

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -709,24 +709,6 @@ class graphite (
   validate_integer($gr_web_server_port)
   validate_integer($gr_web_server_port_https)
 
-
-
-  # Set things
-  case $gr_web_server {
-    'apache': {
-      $gr_web_user_REAL = pick($gr_web_user, $::graphite::params::apache_web_user)
-      $gr_web_group_REAL = pick($gr_web_group, $::graphite::params::apache_web_group)
-    }
-    'nginx': {
-      $gr_web_user_REAL = pick($gr_web_user, $::graphite::params::nginx_web_user)
-      $gr_web_group_REAL = pick($gr_web_group, $::graphite::params::nginx_web_group)
-    }
-    'wsgionly': {
-      $gr_web_user_REAL = pick($gr_web_user)
-      $gr_web_group_REAL = pick($gr_web_group)
-    }
-  }
-
   # The anchor resources allow the end user to establish relationships
   # to the "main" class and preserve the relationship to the
   # implementation classes through a transitive relationship to

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,8 +118,7 @@
 #   (matches the exammple configuration from graphite 0.9.12)
 # [*gr_web_server*]
 #   The web server to use.
-#   Valid values are 'apache', 'nginx', 'wsgionly' and 'none'. 'nginx' is only
-#   supported on Debian-like systems.
+#   Valid values are 'apache', 'nginx', 'wsgionly' and 'none'. 
 #   'wsgionly' will omit apache and nginx, allowing you to run your own
 #   webserver and communicate via wsgi to the unix socket. Handy for servers
 #   with multiple vhosts/purposes etc.
@@ -127,6 +126,14 @@
 #   apache and gunicorn/nginx. All other webserver settings below are
 #   irrelevant if this is 'wsgionly' or 'none'.
 #   Default is 'apache'.
+# [*gr_web_server_port*]
+#   The port which the web server will bind to for the graphite web server. Only
+#   applicable for $gr_web_server => 'apache' or 'nginx'.
+#   Default is 80.
+# [*gr_web_server_port_https*]
+#   The port to run SSL web server on if you have an existing web server on
+#   the default port 443. Only applicable for $gr_web_server => 'apache'.
+#   Default is 443.
 # [*gr_web_servername*]
 #   Virtualhostname of Graphite webgui.
 #   Default is FQDN.
@@ -137,6 +144,9 @@
 # [*gr_web_cors_allow_from_all*]
 #   Include CORS Headers for all hosts (*) in web server config
 #   Default is false.
+# [*gr_web_server_remove_default*]
+#   Remove the default configuration for apache or nginx.
+#   Default is undef, which removes the default configuration only if the server is running on port 80.
 # [*gr_use_ssl*]
 #   If true, alter web server config to enable SSL.
 #   Default is false.
@@ -149,13 +159,6 @@
 # [*gr_ssl_dir]
 #   Path to SSL dir containing keys and certs.
 #   Default is undef
-# [*gr_apache_port*]
-#   The port to run graphite web server on.
-#   Default is 80.
-# [*gr_apache_port_https*]
-#   The port to run SSL web server on if you have an existing web server on
-#   the default port 443.
-#   Default is 443.
 # [*gr_apache_conf_template*]
 #   Template to use for Apache vhost config.
 #   Default is graphite/etc/apache2/sites-available/graphite.conf.erb
@@ -438,19 +441,28 @@
 #   Default: graphite-web
 # [*gr_graphite_ver*]
 #   String. The version of the graphite package to install
-#   Default: 0.9.12
+#   Default: 0.9.15
 # [*gr_carbon_pkg*]
 #   String. The name of the carbon package to install
 #   Default: carbon
 # [*gr_carbon_ver*]
 #   String. The version of the carbon package to install
-#   Default: 0.9.12
+#   Default: 0.9.15
 # [*gr_whisper_pkg*]
 #   String. The name of the whisper package to install
 #   Default: whisper
 # [*gr_whisper_ver*]
 #   String. The version of the whisper package to install
-#   Default: 0.9.12
+#   Default: 0.9.15
+# [*gr_django_pkg*]
+#   String. The name of the whisper package to install
+#   Default: whisper
+# [*gr_django_ver*]
+#   String. The version of the whisper package to install
+#   Default: 0.9.15
+# [*gr_django_provider*]
+#   String. The provider to use for installing django.
+#   Default: pip
 # [*gr_pip_install*]
 #   Boolean. Should the package be installed via pip
 #   Default: true
@@ -461,6 +473,12 @@
 #   Boolean. Should the caching of the webapp be disabled. This helps with some
 #   display issues in grafana.
 #   Default: false
+# [*gr_apache_port*]
+#   DEPRECATED. Use `gr_web_server_port` now. Trying to set this variable will
+#   cause puppet to fail.
+# [*gr_apache_port_https*]
+#   DEPRECATED. Use `gr_web_server_port_https` now. Trying to set this variable will
+#   cause puppet to fail.
 #
 # === Examples
 #
@@ -531,16 +549,17 @@ class graphite (
     }
   },
   $gr_web_server                          = 'apache',
+  $gr_web_server_port                     = 80,
+  $gr_web_server_port_https               = 443,
   $gr_web_servername                      = $::fqdn,
-  $gr_web_group                           = $graphite::params::web_group,
-  $gr_web_user                            = $graphite::params::web_user,
+  $gr_web_group                           = undef,
+  $gr_web_user                            = undef,
   $gr_web_cors_allow_from_all             = false,
+  $gr_web_server_remove_default           = undef,
   $gr_use_ssl                             = false,
   $gr_ssl_cert                            = undef,
   $gr_ssl_key                             = undef,
   $gr_ssl_dir                             = undef,
-  $gr_apache_port                         = 80,
-  $gr_apache_port_https                   = 443,
   $gr_apache_conf_template                = 'graphite/etc/apache2/sites-available/graphite.conf.erb',
   $gr_apache_conf_prefix                  = '',
   $gr_apache_24                           = $::graphite::params::apache_24,
@@ -660,7 +679,9 @@ class graphite (
   $gr_carbonlink_hosts_timeout            = '1.0',
   $gr_rendering_hosts                     = undef,
   $gr_rendering_hosts_timeout             = '1.0',
-  $gr_prefetch_cache                      = undef
+  $gr_prefetch_cache                      = undef,
+  $gr_apache_port                         = undef,
+  $gr_apache_port_https                   = undef,
 ) inherits graphite::params {
   # Validation of input variables.
   # TODO - validate all the things
@@ -679,9 +700,32 @@ class graphite (
   validate_bool($gr_manage_python_packages)
   validate_bool($gr_disable_webapp_cache)
 
+  if $gr_apache_port or $gr_apache_port_https {
+    fail('$gr_apache_port and $gr_apache_port_https are deprecated in favour of $gr_web_server_port and $gr_web_server_port_https')
+  }
+
+
   # validate integers
-  validate_integer($gr_apache_port)
-  validate_integer($gr_apache_port_https)
+  validate_integer($gr_web_server_port)
+  validate_integer($gr_web_server_port_https)
+
+
+
+  # Set things
+  case $gr_web_server {
+    'apache': {
+      $gr_web_user_REAL = pick($gr_web_user, $::graphite::params::apache_web_user)
+      $gr_web_group_REAL = pick($gr_web_group, $::graphite::params::apache_web_group)
+    }
+    'nginx': {
+      $gr_web_user_REAL = pick($gr_web_user, $::graphite::params::nginx_web_user)
+      $gr_web_group_REAL = pick($gr_web_group, $::graphite::params::nginx_web_group)
+    }
+    'wsgionly': {
+      $gr_web_user_REAL = pick($gr_web_user)
+      $gr_web_group_REAL = pick($gr_web_group)
+    }
+  }
 
   # The anchor resources allow the end user to establish relationships
   # to the "main" class and preserve the relationship to the

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -65,10 +65,6 @@ class graphite::install inherits graphite::params {
   ensure_packages($::graphite::params::graphitepkgs)
 
   create_resources('package',{
-    'twisted' => {
-      ensure => $::graphite::gr_twisted_ver,
-      name   => $::graphite::gr_twisted_pkg,
-    },
     'carbon' => {
       ensure => $::graphite::gr_carbon_ver,
       name   => $::graphite::gr_carbon_pkg,
@@ -80,6 +76,14 @@ class graphite::install inherits graphite::params {
     'graphite-web' => {
       ensure => $::graphite::gr_graphite_ver,
       name   => $::graphite::gr_graphite_pkg,
+    },
+    'twisted' => {
+      ensure  => $::graphite::gr_twisted_ver,
+      name    => $::graphite::gr_twisted_pkg,
+      before  => [
+        Package['txamqp'],
+        Package['carbon'],
+      ],
     },
     'txamqp' => {
       ensure => $::graphite::gr_txamqp_ver,
@@ -98,7 +102,6 @@ class graphite::install inherits graphite::params {
     package { $::graphite::gr_django_pkg :
       ensure   => $::graphite::gr_django_ver,
       provider => $::graphite::gr_django_provider,
-      before   => Package[$::graphite::params::graphitepkgs],
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,7 @@ class graphite::params {
   $whisper_pkg        = 'whisper'
   $whisper_ver        = '0.9.15'
   $django_pkg         = 'Django'
-  $django_ver         = '1.6'
+  $django_ver         = '1.5'
   $django_provider    = 'pip'
 
   $install_prefix     = '/opt/'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,12 +23,11 @@ class graphite::params {
   $carbon_ver         = '0.9.15'
   $whisper_pkg        = 'whisper'
   $whisper_ver        = '0.9.15'
-
-  $django_ver         = 'installed'
-  $django_provider    = undef
+  $django_pkg         = 'Django'
+  $django_ver         = '1.6'
+  $django_provider    = 'pip'
 
   $install_prefix     = '/opt/'
-  $nginxconf_dir      = '/etc/nginx/sites-available'
 
   case $::osfamily {
     'Debian': {
@@ -40,15 +39,17 @@ class graphite::params {
       $apacheconf_dir            = '/etc/apache2/sites-available'
       $apacheports_file          = 'ports.conf'
 
-      $web_group = 'www-data'
-      $web_user = 'www-data'
+      $nginxconf_dir    = '/etc/nginx/sites-available'
+
+      $apache_web_group = 'www-data'
+      $apache_web_user  = 'www-data'
+      $nginx_web_group  = 'www-data'
+      $nginx_web_user   = 'www-data'
 
       $python_dev_pkg = 'python-dev'
 
-      $django_pkg = 'python-django'
-      $graphitepkgs = [
+      $common_os_pkgs = [
         'python-tz',
-        'python-cairo',
         'python-ldap',
         'python-memcache',
         'python-mysqldb',
@@ -59,11 +60,13 @@ class graphite::params {
 
       case $::lsbdistcodename {
         /squeeze|wheezy|precise/: {
-          $apache_24               = false
+          $apache_24          = false
+          $graphitepkgs       = union($common_os_pkgs, ['python-cairo',])
         }
 
-        /jessie|trusty|utopic|vivid/: {
-          $apache_24               = true
+        /jessie|trusty|utopic|vivid|wily/: {
+          $apache_24          = true
+          $graphitepkgs       = union($common_os_pkgs, ['python-cairo',])
         }
 
         default: {
@@ -81,14 +84,17 @@ class graphite::params {
       $apacheconf_dir            = '/etc/httpd/conf.d'
       $apacheports_file          = 'graphite_ports.conf'
 
-      $web_group = 'apache'
-      $web_user = 'apache'
+      $nginxconf_dir    = '/etc/nginx/conf.d'
+
+      $apache_web_group = 'apache'
+      $apache_web_user  = 'apache'
+      $nginx_web_group  = 'nginx'
+      $nginx_web_user   = 'nginx'
 
       $python_dev_pkg = ['python-devel','gcc']
       $common_os_pkgs = [
         'MySQL-python',
         'pyOpenSSL',
-        'pycairo',
         'python-crypto',
         'python-ldap',
         'python-memcached',
@@ -100,15 +106,13 @@ class graphite::params {
       # see https://github.com/graphite-project/carbon/issues/86
       case $::operatingsystemrelease {
         /^6\.\d+$/: {
-          $apache_24    = false
-          $django_pkg = 'Django14'
-          $graphitepkgs = union($common_os_pkgs,['python-sqlite2','bitmap-fonts-compat','bitmap'])
+          $apache_24           = false
+          $graphitepkgs        = union($common_os_pkgs,['python-sqlite2', 'bitmap-fonts-compat', 'bitmap', 'pycairo'])
         }
 
         /^7\.\d+/: {
-          $apache_24    = true
-          $django_pkg = 'python-django'
-          $graphitepkgs = union($common_os_pkgs,['python-sqlite3dbm','dejavu-fonts-common','dejavu-sans-fonts'])
+          $apache_24           = true
+          $graphitepkgs        = union($common_os_pkgs,['python-sqlite3dbm', 'dejavu-fonts-common', 'dejavu-sans-fonts', 'python-cairocffi'])
         }
 
         default: {

--- a/metadata.json
+++ b/metadata.json
@@ -49,6 +49,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
+        "12.04",
         "14.04",
         "15.10"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -1,4 +1,15 @@
 {
+  "name": "dwerder-graphite",
+  "version": "5.16.0",
+  "source": "git clone https://github.com/echocat/puppet-graphite.git",
+  "author": "Daniel Werdermann",
+  "license": "Apache-2.0",
+  "summary": "Installs and configures graphite, carbon (caches,relays,aggregators) and whisper",
+  "project_page": "https://github.com/echocat/puppet-graphite",
+  "issues_url": "https://github.com/echocat/puppet-graphite/issues",
+  "dependencies": [
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0"}
+  ],
     "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
@@ -22,6 +33,13 @@
       ]
     },
     {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "7",
@@ -31,15 +49,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
-        "14.04"
-      ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "6",
-        "7"
+        "14.04",
+        "15.10"
       ]
     }
   ],
@@ -52,17 +63,5 @@
       "name": "puppet",
       "version_requirement": ">=2.7.20 <5.0.0"
     }
-  ],
-  "name": "dwerder-graphite",
-  "version": "5.16.0",
-  "source": "git clone https://github.com/echocat/puppet-graphite.git",
-  "author": "Daniel Werdermann",
-  "license": "Apache-2.0",
-  "summary": "Installs and configures graphite, carbon (caches,relays,aggregators) and whisper",
-  "project_page": "https://github.com/echocat/puppet-graphite",
-  "issues_url": "https://github.com/echocat/puppet-graphite/issues",
-  "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0"}
   ]
-
 }

--- a/spec/classes/graphite_spec.rb
+++ b/spec/classes/graphite_spec.rb
@@ -36,7 +36,7 @@ describe 'graphite' do
   end
 
   context 'Debian supported platforms' do
-    ['trusty','squeeze'].each do | lsbdistcodename |
+    ['trusty','squeeze', 'vivid', 'precise'].each do | lsbdistcodename |
       let(:facts) {{ :osfamily => 'Debian', :lsbdistcodename => lsbdistcodename}}
       describe "Lsbdistcodename #{lsbdistcodename}" do
         it_behaves_like 'supported'

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -49,7 +49,7 @@ describe 'graphite::install', :type => 'class' do
   end
 
   shared_context 'no django' do
-    ['python-django','Django14'].each do |pkg|
+    ['Django', 'python-django','Django14'].each do |pkg|
       it { should_not contain_package(pkg) }
     end
   end
@@ -62,14 +62,14 @@ describe 'graphite::install', :type => 'class' do
     it { should contain_package('gcc').with_provider(nil) }
     it { should contain_package('MySQL-python').with_provider(nil) }
     it { should contain_package('pyOpenSSL').with_provider(nil) }
-    it { should contain_package('pycairo').with_provider(nil) }
     it { should contain_package('python-crypto').with_provider(nil) }
     it { should contain_package('python-memcached').with_provider(nil) }
     it { should contain_package('python-zope-interface').with_provider(nil) }
   end
 
   shared_context 'RedHat 6 platforms' do
-    it { should contain_package('Django14').with_provider(nil) }
+    it { should contain_package('pycairo').with_provider(nil) }
+    it { should contain_package('Django').with_provider('pip') }
     it { should contain_package('python-sqlite2').with_provider(nil) }
     it { should contain_package('bitmap').with_provider(nil) }
     it { should contain_package('bitmap-fonts-compat').with_provider(nil) }
@@ -85,7 +85,8 @@ describe 'graphite::install', :type => 'class' do
   end
 
   shared_context 'RedHat 7 platforms' do
-    it { should contain_package('python-django').with_provider(nil) }
+    it { should contain_package('python-cairocffi').with_provider(nil) }
+    it { should contain_package('Django').with_provider('pip') }
     it { should contain_package('python-sqlite3dbm').with_provider(nil) }
     it { should contain_package('dejavu-fonts-common').with_provider(nil) }
     it { should contain_package('dejavu-sans-fonts').with_provider(nil) }
@@ -101,8 +102,7 @@ describe 'graphite::install', :type => 'class' do
   end
 
   shared_context 'Debian supported platforms' do
-    it { should contain_package('python-django').with_provider(nil) }
-
+    it { should contain_package('Django').with_provider('pip') }
     it { should contain_package('python-cairo').with_provider(nil) }
     it { should contain_package('python-memcache').with_provider(nil) }
     it { should contain_package('python-mysqldb').with_provider(nil) }

--- a/templates/etc/apache2/ports.conf.erb
+++ b/templates/etc/apache2/ports.conf.erb
@@ -5,8 +5,8 @@
 # Debian etch). See /usr/share/doc/apache2.2-common/NEWS.Debian.gz and
 # README.Debian.gz
 
-NameVirtualHost *:<%= scope.lookupvar('graphite::gr_apache_port') %>
-Listen <%= scope.lookupvar('graphite::gr_apache_port') %>
+NameVirtualHost *:<%= scope.lookupvar('graphite::gr_web_server_port') %>
+Listen <%= scope.lookupvar('graphite::gr_web_server_port') %>
 
 <IfModule mod_ssl.c>
     # If you add NameVirtualHost *:443 here, you will also have to change
@@ -14,9 +14,9 @@ Listen <%= scope.lookupvar('graphite::gr_apache_port') %>
     # to <VirtualHost *:443>
     # Server Name Indication for SSL named virtual hosts is currently not
     # supported by MSIE on Windows XP.
-    Listen <%= scope.lookupvar('graphite::gr_apache_port_https') %>
+    Listen <%= scope.lookupvar('graphite::gr_web_server_port_https') %>
 </IfModule>
 
 <IfModule mod_gnutls.c>
-    Listen <%= scope.lookupvar('graphite::gr_apache_port_https') %>
+    Listen <%= scope.lookupvar('graphite::gr_web_server_port_https') %>
 </IfModule>

--- a/templates/etc/apache2/sites-available/graphite.conf.erb
+++ b/templates/etc/apache2/sites-available/graphite.conf.erb
@@ -17,7 +17,7 @@
 # Read http://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGISocketPrefix
 WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefix') %>
 
-<VirtualHost *:<%= scope.lookupvar('graphite::gr_apache_port') %>>
+<VirtualHost *:<%= scope.lookupvar('graphite::gr_web_server_port') %>>
 	ServerName <%= scope.lookupvar('graphite::gr_web_servername') %>
 	DocumentRoot "/opt/graphite/webapp"
 <% if ![nil, '', :undef].include?(scope.lookupvar('graphite::gr_apache_noproxy')) %>  NoProxy <%= scope.lookupvar('graphite::gr_apache_noproxy') %><% end %>

--- a/templates/etc/gunicorn.d/graphite.erb
+++ b/templates/etc/gunicorn.d/graphite.erb
@@ -1,8 +1,8 @@
 CONFIG = {
     'mode': 'django',
     'working_dir': '/opt/graphite/webapp/graphite',
-    'user': '<%= scope.lookupvar('graphite::gr_web_user') %>',
-    'group': '<%= scope.lookupvar('graphite::gr_web_group') %>',
+    'user': '<%= scope.lookupvar('graphite::gr_web_user_REAL') %>',
+    'group': '<%= scope.lookupvar('graphite::gr_web_group_REAL') %>',
     'args': (
 	'--timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %>',
         '--bind=<%= scope.lookupvar('graphite::gunicorn_bind') %>',

--- a/templates/etc/gunicorn.d/graphite.erb
+++ b/templates/etc/gunicorn.d/graphite.erb
@@ -1,11 +1,11 @@
 CONFIG = {
     'mode': 'django',
     'working_dir': '/opt/graphite/webapp/graphite',
-    'user': '<%= scope.lookupvar('graphite::gr_web_user_REAL') %>',
-    'group': '<%= scope.lookupvar('graphite::gr_web_group_REAL') %>',
+    'user': '<%= scope.lookupvar('graphite::config::gr_web_user_REAL') %>',
+    'group': '<%= scope.lookupvar('graphite::config::gr_web_group_REAL') %>',
     'args': (
-	'--timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %>',
+        '--timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %>',
         '--bind=<%= scope.lookupvar('graphite::gunicorn_bind') %>',
-	'--workers=<%= scope.lookupvar('graphite::gunicorn_workers') %>',
+        '--workers=<%= scope.lookupvar('graphite::gunicorn_workers') %>',
     ),
 }

--- a/templates/etc/init.d/RedHat/gunicorn.erb
+++ b/templates/etc/init.d/RedHat/gunicorn.erb
@@ -1,0 +1,103 @@
+#!/bin/sh
+#
+# gunicorn        Startup script for gunicorn
+#
+# chkconfig: - 86 14
+# processname: gunicorn
+# pidfile: /var/run/gunicorn.pid
+# description: Python application server
+#
+### BEGIN INIT INFO
+# Provides: gunicorn
+# Required-Start: $local_fs $remote_fs $network
+# Required-Stop: $local_fs $remote_fs $network
+# Default-Start: 3
+# Default-Stop: 0 1 2 4 5 6
+# Short-Description: start and stop gunicorn
+### END INIT INFO
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+prog=gunicorn
+APP_ROOT=/opt/graphite/webapp/
+lockfile=${LOCKFILE-/var/lock/subsys/gunicorn}
+pidfile=/var/run/gunicorn.pid
+pidfile_old=${pidfile}.oldbin
+RETVAL=0
+ENV=production
+
+
+start() {
+    echo -n $"Starting $prog: "
+    cd $APP_ROOT
+    gunicorn --pid $pidfile --daemon graphite.wsgi:application --timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %> --bind=<%= scope.lookupvar('graphite::gunicorn_bind') %> --workers=<%= scope.lookupvar('graphite::gunicorn_workers') %> --user <%= scope.lookupvar('graphite::gr_web_user_REAL') %> --group <%= scope.lookupvar('graphite::gr_web_group_REAL') %> --chdir /opt/graphite/webapp/ --access-logfile /opt/graphite/storage/access-gunicorn.log --error-logfile /opt/graphite/storage/error-gunicorn.log
+    RETVAL=$?
+    echo -n
+    [ $RETVAL = 1 ] && echo -e '[\e[31m FAILED \e[m]'
+    [ $RETVAL = 0 ] && echo -e '[\e[32m OK \e[m]'
+    [ $RETVAL = 0 ] && touch ${lockfile}
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc -p ${pidfile} ${prog} -QUIT
+    RETVAL=$?
+    echo
+    [ $RETVAL = 0 ] && rm -f ${lockfile} ${pidfile}
+}
+
+restart() {
+    echo -n $"Restarting $prog: "
+    killproc -p ${pidfile} ${prog} -USR2
+    RETVAL=$?
+    echo
+    echo -n $"Stopping old $prog: "
+    killproc -p ${pidfile_old} ${prog} -QUIT
+    RETVAL=$?
+    echo
+}
+
+reload() {
+    echo -n $"Reloading $prog: "
+    killproc -p ${pidfile} ${prog} -HUP
+    RETVAL=$?
+    echo
+}
+
+rh_status() {
+    status -p ${pidfile} ${prog}
+}
+
+# See how we were called.
+case "$1" in
+    start)
+        rh_status >/dev/null 2>&1 && exit 0
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart)
+        restart
+        ;;
+    reload)
+        reload
+        ;;
+    condrestart|try-restart)
+        if rh_status >/dev/null 2>&1; then
+            stop
+            start
+        fi
+        ;;
+    status)
+        rh_status
+        RETVAL=$?
+        ;;
+    *)
+        echo $"Usage: $prog {start|stop|restart|reload|condrestart|try-restart|status|help}"
+        RETVAL=2
+esac
+
+exit $RETVAL

--- a/templates/etc/init.d/RedHat/gunicorn.erb
+++ b/templates/etc/init.d/RedHat/gunicorn.erb
@@ -31,7 +31,7 @@ ENV=production
 start() {
     echo -n $"Starting $prog: "
     cd $APP_ROOT
-    gunicorn --pid $pidfile --daemon graphite.wsgi:application --timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %> --bind=<%= scope.lookupvar('graphite::gunicorn_bind') %> --workers=<%= scope.lookupvar('graphite::gunicorn_workers') %> --user <%= scope.lookupvar('graphite::gr_web_user_REAL') %> --group <%= scope.lookupvar('graphite::gr_web_group_REAL') %> --chdir /opt/graphite/webapp/ --access-logfile /opt/graphite/storage/access-gunicorn.log --error-logfile /opt/graphite/storage/error-gunicorn.log
+    gunicorn --pid $pidfile --daemon graphite.wsgi:application --timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %> --bind=<%= scope.lookupvar('graphite::gunicorn_bind') %> --workers=<%= scope.lookupvar('graphite::gunicorn_workers') %> --user <%= scope.lookupvar('graphite::config::gr_web_user_REAL') %> --group <%= scope.lookupvar('graphite::config::gr_web_group_REAL') %> --chdir /opt/graphite/webapp/ --access-logfile /opt/graphite/storage/access-gunicorn.log --error-logfile /opt/graphite/storage/error-gunicorn.log
     RETVAL=$?
     echo -n
     [ $RETVAL = 1 ] && echo -e '[\e[31m FAILED \e[m]'

--- a/templates/etc/nginx/sites-available/graphite.erb
+++ b/templates/etc/nginx/sites-available/graphite.erb
@@ -33,7 +33,7 @@ server {
 		proxy_connect_timeout 10;
 		proxy_read_timeout <%= scope.lookupvar('graphite::nginx_proxy_read_timeout') %>;
 
-		proxy_pass http://unix:/var/run/graphite.sock:/;
+		proxy_pass http://<%= scope.lookupvar('graphite::gunicorn_bind') %>:/;
 
 	<% if scope.lookupvar('graphite::gr_web_cors_allow_from_all') %>
 		add_header Access-Control-Allow-Origin "*";

--- a/templates/etc/nginx/sites-available/graphite.erb
+++ b/templates/etc/nginx/sites-available/graphite.erb
@@ -1,6 +1,6 @@
 # Serve static files directly and redirect remaining requests to graphite
 server {
-	listen   <%= scope.lookupvar('graphite::gr_apache_port') %>;
+	listen   <%= scope.lookupvar('graphite::gr_web_server_port') %>;
 	server_name <%= scope.lookupvar('graphite::gr_web_servername') %>;
 
 	client_max_body_size 64M;

--- a/templates/etc/systemd/gunicorn.service.erb
+++ b/templates/etc/systemd/gunicorn.service.erb
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 PIDFile=/run/gunicorn.pid
 WorkingDirectory=/opt/graphite/webapp/graphite
-ExecStart=/usr/bin/gunicorn --pid /run/gunicorn.pid --timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %> --bind=<%= scope.lookupvar('graphite::gunicorn_bind') %> --workers=<%= scope.lookupvar('graphite::gunicorn_workers') %> --user <%= scope.lookupvar('graphite::gr_web_user_REAL') %> --group <%= scope.lookupvar('graphite::gr_web_group_REAL') %> --access-logfile /opt/graphite/storage/access-gunicorn.log --error-logfile /opt/graphite/storage/error-gunicorn.log wsgi:application
+ExecStart=/usr/bin/gunicorn --pid /run/gunicorn.pid --timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %> --bind=<%= scope.lookupvar('graphite::gunicorn_bind') %> --workers=<%= scope.lookupvar('graphite::gunicorn_workers') %> --user <%= scope.lookupvar('graphite::config::gr_web_user_REAL') %> --group <%= scope.lookupvar('graphite::config::gr_web_group_REAL') %> --access-logfile /opt/graphite/storage/access-gunicorn.log --error-logfile /opt/graphite/storage/error-gunicorn.log wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true

--- a/templates/etc/systemd/gunicorn.service.erb
+++ b/templates/etc/systemd/gunicorn.service.erb
@@ -1,0 +1,15 @@
+[Unit]
+Description=gunicorn daemon
+Requires=gunicorn.socket
+After=network.target
+
+[Service]
+PIDFile=/run/gunicorn.pid
+WorkingDirectory=/opt/graphite/webapp/graphite
+ExecStart=/usr/bin/gunicorn --pid /run/gunicorn.pid --timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %> --bind=<%= scope.lookupvar('graphite::gunicorn_bind') %> --workers=<%= scope.lookupvar('graphite::gunicorn_workers') %> --user <%= scope.lookupvar('graphite::gr_web_user_REAL') %> --group <%= scope.lookupvar('graphite::gr_web_group_REAL') %> --access-logfile /opt/graphite/storage/access-gunicorn.log --error-logfile /opt/graphite/storage/error-gunicorn.log wsgi:application
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/etc/systemd/gunicorn.socket.erb
+++ b/templates/etc/systemd/gunicorn.socket.erb
@@ -1,0 +1,8 @@
+[Unit]
+Description=gunicorn socket
+
+[Socket]
+ListenStream=<%= scope.lookupvar('graphite::gunicorn_bind')[/unix:(.*)/, 1] %>
+
+[Install]
+WantedBy=sockets.target

--- a/templates/etc/tmpfiles.d/gunicorn.conf.erb
+++ b/templates/etc/tmpfiles.d/gunicorn.conf.erb
@@ -1,0 +1,1 @@
+d /run/gunicorn 0755 <%= scope.lookupvar('graphite::gr_web_user_REAL') %> <%= scope.lookupvar('graphite::gr_web_group_REAL') %> -

--- a/templates/etc/tmpfiles.d/gunicorn.conf.erb
+++ b/templates/etc/tmpfiles.d/gunicorn.conf.erb
@@ -1,1 +1,1 @@
-d /run/gunicorn 0755 <%= scope.lookupvar('graphite::gr_web_user_REAL') %> <%= scope.lookupvar('graphite::gr_web_group_REAL') %> -
+d /run/gunicorn 0755 <%= scope.lookupvar('graphite::config::gr_web_user_REAL') %> <%= scope.lookupvar('graphite::config::gr_web_group_REAL') %> -

--- a/templates/opt/graphite/conf/carbon.conf.erb
+++ b/templates/opt/graphite/conf/carbon.conf.erb
@@ -60,8 +60,8 @@ MAX_UPDATES_PER_SECOND = <%= scope.lookupvar('graphite::gr_max_updates_per_secon
 # relatively low and carbon has cached a lot of updates; it enables the carbon
 # daemon to shutdown more quickly.
 # MAX_UPDATES_PER_SECOND_ON_SHUTDOWN = 1000
-<% unless [:undef, nil].include? scope['graphite::gr_max_updates_per_second_on_shutdown'] -%>
-MAX_UPDATES_PER_SECOND_ON_SHUTDOWN = <%= scope['graphite::gr_max_updates_per_second_on_shutdown'] %>
+<% unless [:undef, nil].include? scope.lookupvar('graphite::gr_max_updates_per_second_on_shutdown') -%>
+MAX_UPDATES_PER_SECOND_ON_SHUTDOWN = <%= scope.lookupvar('graphite::gr_max_updates_per_second_on_shutdown') %>
 <% end -%>
 
 # Softly limits the number of whisper files that get created each minute.


### PR DESCRIPTION
Changes from upstream:
- Nginx/Gunicorn is now fully supported on both Debian and RedHat-like systems
- The correct username/group is now used across apache/nginx for both Debian
  and RedHat
- Pip is now the default provider for Django to ensure mutually-working package 
  versions are installed.
- Added initscripts for RedHat
- Added workaround for [race condition bug in graphite](https://github.com/graphite-project/graphite-web/issues/403)
- Added configuration variable `gr_web_server_remove_default` -- default config is
  only wiped when the variable is true, or when it is `undef` and 
  `gr_web_server_port` == 80
- Renamed `gr_apache_port` and `gr_apache_port_https` to `gr_web_server_port` and 
  `gr_web_server_port` respectively. If the old configuration values are used, puppet
  throws an error telling you to use the new ones. (If you don't want to bump a major
  version number for these changes, I can change it to a deprecation warning, but
  that's less elegant.)
- Fixed resource chaining bug causing failure on Ubuntu 12.04.5
- Added Compatbility Notes to README

Changes since fork that are in line with latest commits:
- Default package versions of 0.9.15/1.5 for graphite/Django
- Twisted is explicitly installed before txamqp (more reliable than simply reordering)
- Added package `python-tzlocal` package for RedHat

To test the changes, I provisioned stock VMs with puppet and pip. I did two runs of 
puppet apply per OS:
1. `include graphite`
2. `class { 'graphite':
  gr_web_server => 'nginx',
}`

If I could display a metric in the Graphite Composer, then the test passed.

Now for all the caveats:
- CentOS 6/7 requires a symlink from `/usr/bin/pip-python` to `/usr/bin/pip` (see: 
  [PUP-3829](https://tickets.puppetlabs.com/browse/PUP-3829) for CentOS 6/7))
- CentOS 7's default `nginx.conf` includes a `server` section listening on port `80`.
  Thus, it is not possible to set up graphite without modifying the package-provided
  configuration file. I opted to do nothing about this; graphite will successfully,
  but the default `server` section has to be removed from `nginx.conf`. This needs
  to be noted somewhere in the README file.
- These tests were done with SELinux disabled.
- Debian is using the `gunicorn-debian` script, which calls `gunicorn_django`, which is deprecated.
- Everything should be using `python-cairocffi` now, as it's what is recommended/required by graphite. However, Ubuntu 15.10's `python-cairocffi` package is broken (it tries to important `somelib.so` when the actual file is `somelib.so.1`), so I've kept all debian variants using `python-cairo`.
- Ubuntu 15.10 requires a `systemctl restart gunicorn` after install

The following OS's were tested successfully:
- CentOS 6.7
- CentOS 7.2.1511
- Debian 7.9
- Debian 8.2
- Ubuntu 12.04.5
- Ubuntu 14.04.3
- Ubuntu 15.10

The following OS's did not work:
- Ubuntu 15.04
  The pip provider is broken (see [PUP-4502](https://tickets.puppetlabs.com/browse/PUP-4502)