### PR TITLE
Add param for carbon-relay init.d ulimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,9 @@ ones set for the principal instance.
 ```puppet
    class {'graphite':
       gr_line_receiver_port => 2003,
-      gr_pickle_receiver_port => 2004, 
+      gr_pickle_receiver_port => 2004,
       gr_cache_query_port => 7002,
-      
+
       gr_cache_instances => {
          'cache:b' => {
             'LINE_RECEIVER_PORT' => 2103,
@@ -297,6 +297,11 @@ The prefix to be applied to internal performance metrics. Defaults to 'carbon'.
 #####`gr_carbon_metric_interval`
 
 Default is 60. Set the interval between sending internal performance metrics; affects all carbon daemons.
+
+#####`gr_carbon_relay_debian_ulimit`
+
+Default is undef. Set the maximum number of file descriptors for
+carbon-relay process.
 
 #####`gr_line_receiver_interface`
 
@@ -400,7 +405,7 @@ The storage aggregation rules.
 
 #####`gr_web_server`
 
-Default is 'apache'. The web server to configure. Valid values are 'apache', 'nginx', 'wsgionly' or 'none'. 
+Default is 'apache'. The web server to configure. Valid values are 'apache', 'nginx', 'wsgionly' or 'none'.
 
 Apache is configured with mod_wsgi, nginx is configured with gunicorn. 'wsgionly' configures only gunicorn.
 
@@ -728,7 +733,7 @@ Default is 30.  value to pass to gunicorns --timeout arg.
 Default is 'unix:/var/run/graphite.sock'.  value to pass to gunicorns --bind arg.
 
 #####`gunicorn_workers`
-  
+
 Default is 2. value to pass to gunicorn's --worker arg.
 
 #####`gr_cache_instances`    
@@ -881,7 +886,7 @@ the file `templates/opt/graphite/webapp/graphite/local_settings.py.erb`.
 ###Compatibility Notes
 * There is currently an [open ticket](https://tickets.puppetlabs.com/browse/PUP-3829) with Puppet about broken pip support in CentOS 6/7. The
 workaround for this bug is to create a symlink from `/usr/bin/pip-python` (which doesn't exist) to `/usr/bin/pip` (which does).
-* CentOS 7's default `nginx.conf` includes a `server` section listening on port 80. Thus, it is not possible to set up graphite without modifying 
+* CentOS 7's default `nginx.conf` includes a `server` section listening on port 80. Thus, it is not possible to set up graphite without modifying
 the package-provided configuration file. You will have to either manually remove the `server` section, or provide a `gr_web_server_port` other
 than port 80.
 * nginx/gunicorn requires a `systemctl restart gunicorn` after installing on Ubuntu 15.10

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ The prefix to be applied to internal performance metrics. Defaults to 'carbon'.
 
 Default is 60. Set the interval between sending internal performance metrics; affects all carbon daemons.
 
-#####`gr_carbon_relay_debian_ulimit`
+#####`gr_carbon_relay_ulimit`
 
 Default is undef. Set the maximum number of file descriptors for
 carbon-relay process.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,9 @@
 # [*gr_carbon_metric_interval*]
 #   The interval (in seconds) between sending internal performance metrics.
 #   Default is 60; 0 to disable instrumentation
+# [*gr_carbon_relay_debian_ulimit*]
+#   The maximum number of file descriptors available to carbon-relay process
+#   Default is undef
 # [*gr_line_receiver_interface*]
 #   Interface the line receiver listens.
 #   Default is 0.0.0.0
@@ -118,7 +121,7 @@
 #   (matches the exammple configuration from graphite 0.9.12)
 # [*gr_web_server*]
 #   The web server to use.
-#   Valid values are 'apache', 'nginx', 'wsgionly' and 'none'. 
+#   Valid values are 'apache', 'nginx', 'wsgionly' and 'none'.
 #   'wsgionly' will omit apache and nginx, allowing you to run your own
 #   webserver and communicate via wsgi to the unix socket. Handy for servers
 #   with multiple vhosts/purposes etc.
@@ -498,6 +501,7 @@ class graphite (
   $gr_max_creates_per_minute              = 50,
   $gr_carbon_metric_prefix                = 'carbon',
   $gr_carbon_metric_interval              = 60,
+  $gr_carbon_relay_debian_ulimit          = undef,
   $gr_line_receiver_interface             = '0.0.0.0',
   $gr_line_receiver_port                  = 2003,
   $gr_enable_udp_listener                 = 'False',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,7 @@
 # [*gr_carbon_metric_interval*]
 #   The interval (in seconds) between sending internal performance metrics.
 #   Default is 60; 0 to disable instrumentation
-# [*gr_carbon_relay_debian_ulimit*]
+# [*gr_carbon_relay_ulimit*]
 #   The maximum number of file descriptors available to carbon-relay process
 #   Default is undef
 # [*gr_line_receiver_interface*]
@@ -501,7 +501,7 @@ class graphite (
   $gr_max_creates_per_minute              = 50,
   $gr_carbon_metric_prefix                = 'carbon',
   $gr_carbon_metric_interval              = 60,
-  $gr_carbon_relay_debian_ulimit          = undef,
+  $gr_carbon_relay_ulimit          = undef,
   $gr_line_receiver_interface             = '0.0.0.0',
   $gr_line_receiver_port                  = 2003,
   $gr_enable_udp_listener                 = 'False',

--- a/templates/etc/init.d/Debian/carbon-relay.erb
+++ b/templates/etc/init.d/Debian/carbon-relay.erb
@@ -31,6 +31,9 @@ case "${OPERATION}" in
             if [ "${INSTANCE}" = "${CARBON_DAEMON}" ]; then
                 INSTANCE="a";
             fi;
+            <% if @gr_carbon_relay_debian_ulimit -%>
+              ulimit -n <%= @gr_carbon_relay_debian_ulimit %>
+            <% end -%>
             ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start
         done
         ;;

--- a/templates/etc/init.d/Debian/carbon-relay.erb
+++ b/templates/etc/init.d/Debian/carbon-relay.erb
@@ -31,8 +31,8 @@ case "${OPERATION}" in
             if [ "${INSTANCE}" = "${CARBON_DAEMON}" ]; then
                 INSTANCE="a";
             fi;
-            <% if @gr_carbon_relay_debian_ulimit -%>
-              ulimit -n <%= @gr_carbon_relay_debian_ulimit %>
+            <% if @gr_carbon_relay_ulimit -%>
+              ulimit -n <%= @gr_carbon_relay_ulimit %>
             <% end -%>
             ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start
         done

--- a/templates/etc/init.d/RedHat/carbon-relay.erb
+++ b/templates/etc/init.d/RedHat/carbon-relay.erb
@@ -37,11 +37,14 @@ start()
         if [ "${INSTANCE}" = "${CARBON_DAEMON}" ]; then
             INSTANCE="a";
         fi;
+        <% if @gr_carbon_relay_ulimit -%>
+          ulimit -n <%= @gr_carbon_relay_ulimit %>
+        <% end -%>
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
         # check if instance is already running
         rh_status_q && continue
-        
+
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start;
         retval=$?
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
@@ -70,7 +73,7 @@ stop()
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
         # check if instance is already stopped
         rh_status_q || continue
-        
+
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop;
         sleep 3
         while [ -f ${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
@@ -95,7 +98,7 @@ restart() {
         fi;
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
-        
+
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop;
         sleep 3
         while [ -f ${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
@@ -107,7 +110,7 @@ restart() {
         echo -n $"Stopping carbon-${CARBON_DAEMON}:${INSTANCE}..."
         echo_success
         echo
-        
+
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start;
         retval=$?
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid


### PR DESCRIPTION
Creates a param for setting max file descriptors in init.d script

See: http://graphite.readthedocs.org/en/latest/carbon-daemons.html

RFC @dwerder