### PR TITLE
python-crypto obsoleted by python2-crypto on RHEL/CentOS 7.x

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,7 +89,6 @@ class graphite::params {
         'MySQL-python',
         'pyOpenSSL',
         'pycairo',
-        'python-crypto',
         'python-ldap',
         'python-memcached',
         'python-psycopg2',
@@ -102,13 +101,13 @@ class graphite::params {
         /^6\.\d+$/: {
           $apache_24    = false
           $django_pkg = 'Django14'
-          $graphitepkgs = union($common_os_pkgs,['python-sqlite2','bitmap-fonts-compat','bitmap'])
+          $graphitepkgs = union($common_os_pkgs,['python-sqlite2','bitmap-fonts-compat','bitmap','python-crypto'])
         }
 
         /^7\.\d+/: {
           $apache_24    = true
           $django_pkg = 'python-django'
-          $graphitepkgs = union($common_os_pkgs,['python-sqlite3dbm','dejavu-fonts-common','dejavu-sans-fonts'])
+          $graphitepkgs = union($common_os_pkgs,['python-sqlite3dbm','dejavu-fonts-common','dejavu-sans-fonts','python2-crypto'])
         }
 
         default: {

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -63,7 +63,6 @@ describe 'graphite::install', :type => 'class' do
     it { should contain_package('MySQL-python').with_provider(nil) }
     it { should contain_package('pyOpenSSL').with_provider(nil) }
     it { should contain_package('pycairo').with_provider(nil) }
-    it { should contain_package('python-crypto').with_provider(nil) }
     it { should contain_package('python-memcached').with_provider(nil) }
     it { should contain_package('python-zope-interface').with_provider(nil) }
   end
@@ -73,6 +72,7 @@ describe 'graphite::install', :type => 'class' do
     it { should contain_package('python-sqlite2').with_provider(nil) }
     it { should contain_package('bitmap').with_provider(nil) }
     it { should contain_package('bitmap-fonts-compat').with_provider(nil) }
+    it { should contain_package('python-crypto').with_provider(nil) }
 
     it { should contain_file('carbon_hack').only_with(hack_defaults.merge({
       :target => '/opt/graphite/lib/carbon-0.9.15-py2.6.egg-info',
@@ -89,6 +89,7 @@ describe 'graphite::install', :type => 'class' do
     it { should contain_package('python-sqlite3dbm').with_provider(nil) }
     it { should contain_package('dejavu-fonts-common').with_provider(nil) }
     it { should contain_package('dejavu-sans-fonts').with_provider(nil) }
+    it { should contain_package('python2-crypto').with_provider(nil) }
 
     it { should contain_file('carbon_hack').only_with(hack_defaults.merge({
       :target => '/opt/graphite/lib/carbon-0.9.15-py2.7.egg-info',


### PR DESCRIPTION
 - addresses #243