### PR TITLE
set the service provider on red hat systems

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -233,6 +233,7 @@ class graphite::config inherits graphite::params {
       enable     => true,
       hasrestart => true,
       hasstatus  => true,
+      provider   => $service_provider,
       require    => File['/etc/init.d/carbon-cache'],
     }
 
@@ -250,6 +251,7 @@ class graphite::config inherits graphite::params {
       enable     => true,
       hasrestart => true,
       hasstatus  => true,
+      provider   => $service_provider,
       require    => File['/etc/init.d/carbon-relay'],
     }
 
@@ -267,6 +269,7 @@ class graphite::config inherits graphite::params {
       enable     => true,
       hasrestart => true,
       hasstatus  => true,
+      provider   => $service_provider,
       require    => File['/etc/init.d/carbon-aggregator'],
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class graphite::params {
       $apache_wsgi_socket_prefix = '/var/run/apache2/wsgi'
       $apacheconf_dir            = '/etc/apache2/sites-available'
       $apacheports_file          = 'ports.conf'
+      $service_provider          = undef
 
       $web_group = 'www-data'
       $web_user = 'www-data'
@@ -80,6 +81,7 @@ class graphite::params {
       $apache_wsgi_socket_prefix = 'run/wsgi'
       $apacheconf_dir            = '/etc/httpd/conf.d'
       $apacheports_file          = 'graphite_ports.conf'
+      $service_provider          = 'redhat'
 
       $web_group = 'apache'
       $web_user = 'apache'


### PR DESCRIPTION
This forces the puppet service provider to 'redhat' on red hat systems,
which prevents puppet from enabling the init service on RHEL7 systems on
every run.