### PR TITLE
add support for custom directory locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,13 +363,54 @@ Default is 7002. Self explaining.
 
 Default is 'GMT' (string). Timezone for graphite to be used.
 
+#####`gr_base_dir`
+
+Default is '/opt/graphite'. Set base install location of Graphite. This forms the base location for installs, predominantly appropriate for pip installations. When not installing using pip a typical location for this may be '/opt/carbon'.
+
+#####`gr_storage_dir`
+
+Default is '${gr_base_dir}/storage'. Set location of base storage files.  When not installing using pip a typical location for this may be '/opt/carbon'.
+
 #####`gr_local_data_dir`
 
-Default is '/opt/graphite/storage/whisper'. Set location of whisper files.
+Default is '${gr_storage_dir}/whisper'. Set location of whisper files.
 
 #####`gr_rrd_dir`
 
-Default is '/opt/graphite/storage/rrd'. Set location of rrd data files.
+Default is '${gr_storage_dir}/rrd'. Set location of rrd data files.
+
+#####`gr_whitelists_dir`
+
+Default is '${gr_storage_dir}/rrd'. Set location of whitelist configuration files.
+
+#####`gr_carbon_conf_dir`
+
+Default is '${gr_base_dir}/conf'. Set location of Carbon's configuration files. Most relevant when not using pip for installation. A typical location for this may be '/etc/carbon'.
+
+#####`gr_carbon_log_dir`
+
+Default is '${gr_storage_dir}/log/carbon-cache'. Set location of carbon cache log files.
+
+#####`gr_graphiteweb_log_dir`
+
+Default is '${gr_storage_dir}/log'. Set location of graphite web log files.
+
+#####`gr_graphiteweb_conf_dir`
+
+Default is '${gr_base_dir}/conf'. Set location of graphite web configuration.
+
+#####`gr_graphiteweb_webapp_dir`
+
+Default is '${gr_base_dir}/webapp'. Set location of graphite web's webapp files.
+
+#####`gr_graphiteweb_storage_dir`
+
+Default is '/var/lib/graphite-web'. Set location of graphite web's storage, used for graphite.db file.
+
+#####`gr_graphiteweb_install_lib_dir`
+
+Default is '${gr_graphiteweb_webapp_dir}/graphite'. Set location of libraries directory for graphite web.
+
 
 #####`gr_storage_schemas`
 

--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -70,7 +70,7 @@ class graphite::config_apache inherits graphite::params {
   }
   exec { 'fix graphite race condition':
     command     => 'python /tmp/fix-graphite-race-condition.py',
-    cwd         => '/opt/graphite/webapp',
+    cwd         => $graphite::gr_graphiteweb_webapp_dir,
     environment => 'DJANGO_SETTINGS_MODULE=graphite.settings',
     user        => $graphite::config::gr_web_user_REAL,
     logoutput   => true,
@@ -111,7 +111,7 @@ class graphite::config_apache inherits graphite::params {
       mode    => '0644',
       owner   => $::graphite::config::gr_web_user_REAL,
       require => [
-        File['/opt/graphite/storage'],
+        File[$::graphite::gr_storage_dir],
         File["${::graphite::params::apache_dir}/ports.conf"],
       ],
       notify  => Service[$::graphite::params::apache_service_name];

--- a/manifests/config_gunicorn.pp
+++ b/manifests/config_gunicorn.pp
@@ -89,9 +89,9 @@ class graphite::config_gunicorn inherits graphite::params {
   # uses the deprecated `gunicorn_django` command. But, I hope
   # that debian will eventually update their gunicorn package
   # to use the non-deprecated version.
-  file { '/opt/graphite/webapp/graphite/wsgi.py':
+  file { "${graphite::gr_graphiteweb_install_lib_dir}/wsgi.py":
     ensure => link,
-    target => '/opt/graphite/conf/graphite.wsgi',
+    target => "${graphite::gr_graphiteweb_conf_dir}/graphite.wsgi",
     before => Service['gunicorn'],
   }
 
@@ -105,7 +105,7 @@ class graphite::config_gunicorn inherits graphite::params {
     }
     exec { 'fix graphite race condition':
       command     => 'python /tmp/fix-graphite-race-condition.py',
-      cwd         => '/opt/graphite/webapp',
+      cwd         => $graphite::gr_graphiteweb_webapp_dir,
       environment => 'DJANGO_SETTINGS_MODULE=graphite.settings',
       user        => $graphite::config::gr_web_user_REAL,
       logoutput   => true,
@@ -125,8 +125,8 @@ class graphite::config_gunicorn inherits graphite::params {
     $package_name:
       ensure  => installed,
       require => [
-        File['/opt/graphite/storage/run'],
-        File['/opt/graphite/storage/log'],
+        File[$graphite::gr_pid_dir],
+        File[$graphite::gr_graphiteweb_log_dir],
         Exec['Initial django db creation'],
       ];
   }
@@ -139,7 +139,7 @@ class graphite::config_gunicorn inherits graphite::params {
     require    => [
       Package[$package_name],
     ],
-    subscribe  => File['/opt/graphite/webapp/graphite/local_settings.py'],
+    subscribe  => File["${graphite::gr_graphiteweb_conf_dir}/local_settings.py"],
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,13 +66,13 @@
 # [*gr_use_insecure_unpickler*]
 #   Set this to 'True' to revert to the old-fashioned insecure unpickler.
 #   Default is 'False' (String).
-#[*gr_use_whitelist*]
+# [*gr_use_whitelist*]
 #   Set this to 'True' to allow for using whitelists and blacklists.
 #   Default is 'False' (String).
-#[*gr_whitelist*]
+# [*gr_whitelist*]
 #   List of patterns to be included in whitelist.conf.
 #   Default is [ '.*' ]
-#[*gr_blacklist*]
+# [*gr_blacklist*]
 #   List of patterns to be included in blacklist.conf.
 #   Default is [ ]
 # [*gr_cache_query_interface*]
@@ -489,7 +489,7 @@
 #   gr_max_cache_size      => 256,
 #   gr_enable_udp_listener => True,
 #   gr_timezone            => 'Europe/Berlin'
-# }
+#}
 #
 class graphite (
   $gr_group                               = '',
@@ -512,8 +512,8 @@ class graphite (
   $gr_log_listener_connections            = 'True',
   $gr_use_insecure_unpickler              = 'False',
   $gr_use_whitelist                       = 'False',
-  $gr_whitelist                           = [ '.*' ],
-  $gr_blacklist                           = [ ],
+  $gr_whitelist                           = ['.*'],
+  $gr_blacklist                           = [],
   $gr_cache_query_interface               = '0.0.0.0',
   $gr_cache_query_port                    = 7002,
   $gr_cache_write_strategy                = 'sorted',
@@ -523,35 +523,40 @@ class graphite (
       name       => 'carbon',
       pattern    => '^carbon\.',
       retentions => '1m:90d'
-    },
+    }
+    ,
     {
       name       => 'default',
       pattern    => '.*',
       retentions => '1s:30m,1m:1d,5m:2y'
     }
-  ],
+    ],
   $gr_storage_aggregation_rules           = {
-    '00_min' => {
+    '00_min'         => {
       pattern => '\.min$',
-      factor => '0.1',
-      method => 'min'
-    },
-    '01_max' => {
+      factor  => '0.1',
+      method  => 'min'
+    }
+    ,
+    '01_max'         => {
       pattern => '\.max$',
-      factor => '0.1',
-      method => 'max'
-    },
-    '02_sum' => {
+      factor  => '0.1',
+      method  => 'max'
+    }
+    ,
+    '02_sum'         => {
       pattern => '\.count$',
-      factor => '0.1',
-      method => 'sum'
-    },
+      factor  => '0.1',
+      method  => 'sum'
+    }
+    ,
     '99_default_avg' => {
       pattern => '.*',
-      factor => '0.5',
-      method => 'average'
+      factor  => '0.5',
+      method  => 'average'
     }
-  },
+  }
+  ,
   $gr_web_server                          = 'apache',
   $gr_web_server_port                     = 80,
   $gr_web_server_port_https               = 443,
@@ -583,19 +588,22 @@ class graphite (
   $gr_relay_log_listener_connections      = 'True',
   $gr_relay_method                        = 'rules',
   $gr_relay_replication_factor            = 1,
-  $gr_relay_destinations                  = [ '127.0.0.1:2004' ],
+  $gr_relay_destinations                  = ['127.0.0.1:2004'],
   $gr_relay_max_queue_size                = 10000,
   $gr_relay_use_flow_control              = 'True',
   $gr_relay_rules                         = {
-    all => {
+    all          => {
       pattern      => '.*',
-      destinations => [ '127.0.0.1:2004' ]
-    },
-    'default' => {
+      destinations => ['127.0.0.1:2004']
+    }
+    ,
+    'default'    => {
       'default'    => true,
-      destinations => [ '127.0.0.1:2004:a' ]
-    },
-  },
+      destinations => ['127.0.0.1:2004:a']
+    }
+    ,
+  }
+  ,
   $gr_enable_carbon_aggregator            = false,
   $gr_aggregator_line_interface           = '0.0.0.0',
   $gr_aggregator_line_port                = 2023,
@@ -606,7 +614,7 @@ class graphite (
   $gr_aggregator_pickle_port              = 2024,
   $gr_aggregator_log_listener_connections = 'True',
   $gr_aggregator_forward_all              = 'True',
-  $gr_aggregator_destinations             = [ '127.0.0.1:2004' ],
+  $gr_aggregator_destinations             = ['127.0.0.1:2004'],
   $gr_aggregator_replication_factor       = 1,
   $gr_aggregator_max_queue_size           = 10000,
   $gr_aggregator_use_flow_control         = 'True',
@@ -614,7 +622,8 @@ class graphite (
   $gr_aggregator_rules                    = {
     'carbon-all-mem'   => 'carbon.all.memUsage (60) = sum carbon.*.*.memUsage',
     'carbon-class-mem' => 'carbon.all.<class>.memUsage (60) = sum carbon.<class>.*.memUsage',
-    },
+  }
+  ,
   $gr_amqp_enable                         = 'False',
   $gr_amqp_verbose                        = 'False',
   $gr_amqp_host                           = 'localhost',
@@ -641,11 +650,25 @@ class graphite (
   $gr_ldap_base_user                      = '',
   $gr_ldap_base_pass                      = '',
   $gr_ldap_user_query                     = '(username=%s)',
-  $gr_ldap_options                        = {},
+  $gr_ldap_options                        = {
+  }
+  ,
   $gr_use_remote_user_auth                = 'False',
   $gr_remote_user_header_name             = undef,
-  $gr_rrd_dir                             = '/opt/graphite/storage/rrd',
-  $gr_local_data_dir                      = '/opt/graphite/storage/whisper',
+  $gr_base_dir                            = '/opt/graphite',
+  $gr_storage_dir                         = "${gr_base_dir}/storage",
+  $gr_local_data_dir                      = "${gr_storage_dir}/whisper",
+  $gr_rrd_dir                             = "${gr_storage_dir}/rrd",
+  $gr_whitelists_dir                      = "${gr_storage_dir}/lists",
+  $gr_carbon_conf_dir                     = "${gr_base_dir}/conf",
+  $gr_carbon_log_dir                      = "${gr_storage_dir}/log/carbon-cache",
+  $gr_graphiteweb_log_dir                 = "${gr_storage_dir}/log",
+  $gr_graphiteweb_conf_dir                = "${gr_base_dir}/conf",
+  $gr_graphiteweb_webapp_dir              = "${gr_base_dir}/webapp",
+  $gr_graphiteweb_storage_dir             = '/var/lib/graphite-web',
+  $gr_graphiteweb_install_lib_dir         = "${gr_graphiteweb_webapp_dir}/graphite",
+  $gr_pid_dir                             = '/var/run',
+  $gr_apache_logdir                       = '/var/log/httpd/graphite-web',
   $gunicorn_arg_timeout                   = 30,
   $gunicorn_bind                          = 'unix:/var/run/graphite.sock',
   $gunicorn_workers                       = 2,
@@ -658,9 +681,9 @@ class graphite (
   $gr_log_cache_performance               = 'False',
   $gr_log_rendering_performance           = 'False',
   $gr_log_metric_access                   = 'False',
-  $wsgi_processes                         =  5,
-  $wsgi_threads                           =  5,
-  $wsgi_inactivity_timeout                =  120,
+  $wsgi_processes                         = 5,
+  $wsgi_threads                           = 5,
+  $wsgi_inactivity_timeout                = 120,
   $gr_django_tagging_pkg                  = $::graphite::params::django_tagging_pkg,
   $gr_django_tagging_ver                  = $::graphite::params::django_tagging_ver,
   $gr_twisted_pkg                         = $::graphite::params::twisted_pkg,
@@ -685,8 +708,7 @@ class graphite (
   $gr_rendering_hosts_timeout             = '1.0',
   $gr_prefetch_cache                      = undef,
   $gr_apache_port                         = undef,
-  $gr_apache_port_https                   = undef,
-) inherits graphite::params {
+  $gr_apache_port_https                   = undef,) inherits graphite::params {
   # Validation of input variables.
   # TODO - validate all the things
   validate_string($gr_use_remote_user_auth)
@@ -708,7 +730,6 @@ class graphite (
     fail('$gr_apache_port and $gr_apache_port_https are deprecated in favour of $gr_web_server_port and $gr_web_server_port_https')
   }
 
-
   # validate integers
   validate_integer($gr_web_server_port)
   validate_integer($gr_web_server_port_https)
@@ -718,13 +739,14 @@ class graphite (
   # implementation classes through a transitive relationship to
   # the composite class.
   # https://projects.puppetlabs.com/projects/puppet/wiki/Anchor_Pattern
-  Anchor['graphite::begin']->
-  Class['graphite::install']~>
-  Class['graphite::config']->
+  Anchor['graphite::begin'] ->
+  Class['graphite::install'] ~>
+  Class['graphite::config'] ->
   Anchor['graphite::end']
 
-  anchor { 'graphite::begin':}
+  anchor { 'graphite::begin': }
   include graphite::install
   include graphite::config
-  anchor { 'graphite::end':}
+
+  anchor { 'graphite::end': }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,17 +7,16 @@
 # None.
 #
 class graphite::install inherits graphite::params {
-
-  ## Validate
+  # # Validate
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
+
   if $::graphite::gr_pip_install and $::osfamily == 'RedHat' {
-    validate_re($::operatingsystemrelease,'^[6-7]\.\d+',
-    "Unsupported RedHat release: '${::operatingsystemrelease}'")
+    validate_re($::operatingsystemrelease, '^[6-7]\.\d+', "Unsupported RedHat release: '${::operatingsystemrelease}'")
   }
 
-  ## Set class variables
+  # # Set class variables
   $gr_pkg_provider = $::graphite::gr_pip_install ? {
     default => undef,
     true    => 'pip',
@@ -30,32 +29,17 @@ class graphite::install inherits graphite::params {
         Package[$::graphite::params::graphitepkgs],
         Package[$::graphite::params::python_pip_pkg],
         Package[$::graphite::params::python_dev_pkg],
-      ],
-    }
-  } else {
+        ],
+    } } else {
     $gr_pkg_require = $::graphite::gr_pip_install ? {
       default => undef,
-      true    => [
-        Package[$::graphite::params::graphitepkgs],
-      ],
-    }
-  }
+      true    => [Package[$::graphite::params::graphitepkgs],],
+    } }
 
-  # variables to workaround unusual graphite install target:
-  # https://github.com/graphite-project/carbon/issues/86
-  $pyver = $::osfamily ? {
-    default  => '2.7',
-    'RedHat' => $::operatingsystemrelease ? { /^6/ => '2.6', default => '2.7' },
-  }
-  $libpath = $::osfamily ? {
-    'Debian' => "/usr/lib/python${pyver}/dist-packages",
-    'RedHat' => "/usr/lib/python${pyver}/site-packages",
-  }
-  $optpath = '/opt/graphite'
-  $carbon  = "carbon-${::graphite::gr_carbon_ver}-py${pyver}.egg-info"
-  $gweb    = "graphite_web-${::graphite::gr_graphite_ver}-py${pyver}.egg-info"
+  $carbon = "carbon-${::graphite::gr_carbon_ver}-py${::graphite::params::pyver}.egg-info"
+  $gweb   = "graphite_web-${::graphite::gr_graphite_ver}-py${::graphite::params::pyver}.egg-info"
 
-  ## Manage resources
+  # # Manage resources
 
   # for full functionality we need these packages:
   # madatory: python-cairo, python-django, python-twisted,
@@ -64,71 +48,83 @@ class graphite::install inherits graphite::params {
 
   ensure_packages($::graphite::params::graphitepkgs)
 
-  create_resources('package',{
-    'carbon' => {
+  create_resources('package', {
+    'carbon'         => {
       ensure => $::graphite::gr_carbon_ver,
       name   => $::graphite::gr_carbon_pkg,
-    },
+    }
+    ,
     'django-tagging' => {
       ensure => $::graphite::gr_django_tagging_ver,
       name   => $::graphite::gr_django_tagging_pkg,
-    },
-    'graphite-web' => {
+    }
+    ,
+    'graphite-web'   => {
       ensure => $::graphite::gr_graphite_ver,
       name   => $::graphite::gr_graphite_pkg,
-    },
-    'twisted' => {
-      ensure  => $::graphite::gr_twisted_ver,
-      name    => $::graphite::gr_twisted_pkg,
-      before  => [
+    }
+    ,
+    'twisted'        => {
+      ensure => $::graphite::gr_twisted_ver,
+      name   => $::graphite::gr_twisted_pkg,
+      before => [
         Package['txamqp'],
         Package['carbon'],
-      ],
-    },
-    'txamqp' => {
+        ],
+    }
+    ,
+    'txamqp'         => {
       ensure => $::graphite::gr_txamqp_ver,
       name   => $::graphite::gr_txamqp_pkg,
-    },
-    'whisper' => {
+    }
+    ,
+    'whisper'        => {
       ensure => $::graphite::gr_whisper_ver,
       name   => $::graphite::gr_whisper_pkg,
-    },
-  },{
+    }
+    ,
+  }
+  , {
     provider => $gr_pkg_provider,
     require  => $gr_pkg_require,
-  })
+  }
+  )
 
   if $::graphite::gr_django_pkg {
-    package { $::graphite::gr_django_pkg :
+    package { $::graphite::gr_django_pkg:
       ensure   => $::graphite::gr_django_ver,
       provider => $::graphite::gr_django_provider,
     }
   }
 
   if $::graphite::gr_pip_install {
-
     # using the pip package provider requires python-pip
     # also install python headers and libs for pip
     if $::graphite::gr_manage_python_packages {
       ensure_packages(flatten([
         $::graphite::params::python_pip_pkg,
         $::graphite::params::python_dev_pkg,
-      ]))
+        ]))
     }
 
     # hack unusual graphite install target
-    create_resources('file',{
+    create_resources('file', {
       'carbon_hack' => {
-        path   => "${libpath}/${carbon}",
-        target => "${optpath}/lib/${carbon}"
-      },
+        path   => "${::graphite::params::libpath}/${carbon}",
+        target => "${::graphite::gr_base_dir}/lib/${carbon}"
+      }
+      ,
       'gweb_hack'   => {
-        path   => "${libpath}/${gweb}",
-        target => "${optpath}/webapp/${gweb}"
-      },
-    },{
+        path   => "${::graphite::params::libpath}/${gweb}",
+        target => "${::graphite::gr_base_dir}/webapp/${gweb}"
+      }
+      ,
+    }
+    , {
       ensure  => 'link',
-      require => Package['carbon','graphite-web','whisper'],
-    })
+      require => Package[
+        'carbon', 'graphite-web', 'whisper'],
+    }
+    )
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,15 @@ class graphite::params {
 
   $install_prefix     = '/opt/'
 
+  # variables to workaround unusual graphite install target:
+  # https://github.com/graphite-project/carbon/issues/86
+  $pyver              = $::osfamily ? {
+    default  => '2.7',
+    'RedHat' => $::operatingsystemrelease ? {
+      /^6/    => '2.6',
+      default => '2.7'
+    },
+  }
   case $::osfamily {
     'Debian': {
       $apache_dir                = '/etc/apache2'
@@ -74,6 +83,7 @@ class graphite::params {
           fail("Unsupported Debian release: '${::lsbdistcodename}'")
         }
       }
+      $libpath = "/usr/lib/python${pyver}/dist-packages"
     }
 
     'RedHat': {
@@ -120,6 +130,7 @@ class graphite::params {
           fail("Unsupported RedHat release: '${::operatingsystemrelease}'")
         }
       }
+      $libpath = "/usr/lib/python${pyver}/site-packages"
     }
 
     default: {

--- a/templates/etc/apache2/sites-available/graphite.conf.erb
+++ b/templates/etc/apache2/sites-available/graphite.conf.erb
@@ -19,24 +19,24 @@ WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefi
 
 <VirtualHost *:<%= scope.lookupvar('graphite::gr_web_server_port') %>>
 	ServerName <%= scope.lookupvar('graphite::gr_web_servername') %>
-	DocumentRoot "/opt/graphite/webapp"
+	DocumentRoot "<%= scope.lookupvar('graphite::gr_graphiteweb_webapp_dir') %>"
 <% if ![nil, '', :undef].include?(scope.lookupvar('graphite::gr_apache_noproxy')) %>  NoProxy <%= scope.lookupvar('graphite::gr_apache_noproxy') %><% end %>
 
-	ErrorLog /opt/graphite/storage/error.log
-	CustomLog /opt/graphite/storage/access.log common
+	ErrorLog <%= scope.lookupvar('graphite::gr_apache_logdir') %>/graphite-web-error.log
+	CustomLog <%= scope.lookupvar('graphite::gr_apache_logdir') %>/graphite-web-access.log common
 
 	# I've found that an equal number of processes & threads tends
 	# to show the best performance for Graphite (ymmv).
 	WSGIDaemonProcess graphite processes=<%= scope.lookupvar('graphite::wsgi_processes') -%> threads=<%= scope.lookupvar('graphite::wsgi_threads') -%> display-name='%{GROUP}' inactivity-timeout=<%= scope.lookupvar('graphite::wsgi_inactivity_timeout') %>
 	WSGIProcessGroup graphite
 	WSGIApplicationGroup %{GLOBAL}
-	WSGIImportScript /opt/graphite/conf/graphite.wsgi process-group=graphite application-group=%{GLOBAL}
+	WSGIImportScript <%= scope.lookupvar('graphite::gr_graphiteweb_conf_dir') %>/graphite.wsgi process-group=graphite application-group=%{GLOBAL}
 
 	# XXX You will need to create this file! There is a graphite.wsgi.example
 	# file in this directory that you can safely use, just copy it to graphite.wgsi
-	WSGIScriptAlias / /opt/graphite/conf/graphite.wsgi
+	WSGIScriptAlias / <%= scope.lookupvar('graphite::gr_graphiteweb_conf_dir') %>/graphite.wsgi
 
-	Alias /content/ /opt/graphite/webapp/content/
+	Alias /content/ <%= scope.lookupvar('graphite::gr_graphiteweb_webapp_dir') %>/content/
 	<Location "/content/">
 			SetHandler None
 <% if scope.lookupvar('graphite::gr_apache_24') %>
@@ -50,7 +50,7 @@ WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefi
 	# must change @DJANGO_ROOT@ to be the path to your django
 	# installation, which is probably something like:
 	# /usr/lib/python2.6/site-packages/django
-	Alias /media/ "@DJANGO_ROOT@/contrib/admin/media/"
+	Alias /media/ "/usr/lib/python2.6/site-packages/django/contrib/admin/media/"
 	<Location "/media/">
 			SetHandler None
 <% if scope.lookupvar('graphite::gr_apache_24') %>
@@ -62,7 +62,7 @@ WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefi
 
 	# The graphite.wsgi file has to be accessible by apache. It won't
 	# be visible to clients because of the DocumentRoot though.
-	<Directory /opt/graphite/conf/>
+	<Directory <%= scope.lookupvar('graphite::gr_graphiteweb_conf_dir') %> >
 <% if scope.lookupvar('graphite::gr_apache_24') %>
 			Options All
 			AllowOverride All

--- a/templates/etc/init.d/RedHat/carbon-cache.erb
+++ b/templates/etc/init.d/RedHat/carbon-cache.erb
@@ -4,7 +4,7 @@
 # chkconfig: 345 80 20
 # description: Start/Stop carbon-cache
 # processname: carbon-cache
-# config: /opt/graphite/conf/carbon.conf
+# config: '<%= scope.lookupvar('graphite::gr_carbon_conf_dir') %>/carbon.conf'
 
 ### BEGIN INIT INFO
 # Provides: carbon-cache
@@ -21,14 +21,14 @@
 
 PYTHON_CMD='python -W ignore'
 CARBON_DAEMON="cache"
-GRAPHITE_DIR="/opt/graphite"
+GRAPHITE_DIR="<%= scope.lookupvar('graphite::gr_base_dir') %>"
 pidfile=""
 OPERATION="$1"
 if [ $# -gt 1 ]; then
     shift
     INSTANCES=$*
 else
-    INSTANCES=$(grep "^\[${CARBON_DAEMON}" ${GRAPHITE_DIR}/conf/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
+    INSTANCES=$(grep "^\[${CARBON_DAEMON}" <%= scope.lookupvar('graphite::gr_carbon_conf_dir') %>/carbon.conf | cut -d \[ -f 2 | cut -d \] -f 1 | cut -d : -f 2)
 fi
 
 start()
@@ -37,12 +37,16 @@ start()
         if [ "${INSTANCE}" = "${CARBON_DAEMON}" ]; then
             INSTANCE="a";
         fi;
-        pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
+        pidfile=<%= scope.lookupvar('graphite::gr_pid_dir') %>/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
         # check if instance is already running
         rh_status_q && continue
         
-        ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start;
+        # If installed from source use this
+        CARBON_PY=${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py
+        # else use /user/bin/carbon-cache
+        
+        ${PYTHON_CMD} ${CARBON_PY} --instance=${INSTANCE} start;
         retval=$?
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         echo -n $"Starting carbon-${CARBON_DAEMON}:${INSTANCE}..."

--- a/templates/opt/graphite/conf/graphite.wsgi.erb
+++ b/templates/opt/graphite/conf/graphite.wsgi.erb
@@ -2,7 +2,8 @@
 
 import os
 import sys
-sys.path.append('/opt/graphite/webapp')
+#sys.path.append('/opt/graphite/webapp')
+sys.path.append('<%= scope.lookupvar('graphite::gr_graphiteweb_webapp_dir') %>')
 
 try:
     from importlib import import_module

--- a/templates/opt/graphite/webapp/graphite/local_settings.py.erb
+++ b/templates/opt/graphite/webapp/graphite/local_settings.py.erb
@@ -75,6 +75,9 @@ CACHES = {
 #CONF_DIR = '/opt/graphite/conf'
 #STORAGE_DIR = '/opt/graphite/storage'
 #CONTENT_DIR = '/opt/graphite/webapp/content'
+CONF_DIR = '<%= scope.lookupvar('graphite::gr_graphiteweb_conf_dir') %>'
+STORAGE_DIR = '<%= scope.lookupvar('graphite::gr_graphiteweb_storage_dir') %>'
+CONTENT_DIR = '<%= scope.lookupvar('graphite::gr_graphiteweb_webapp_dir') %>/content'
 
 # To further or fully customize the paths, modify the following. Note that the
 # default settings for each of these are relative to CONF_DIR and STORAGE_DIR
@@ -88,7 +91,7 @@ CACHES = {
 WHISPER_DIR = '<%= scope.lookupvar('graphite::gr_local_data_dir') %>'
 RRD_DIR = '<%= scope.lookupvar('graphite::gr_rrd_dir') %>'
 #DATA_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables
-#LOG_DIR = '/opt/graphite/storage/log/webapp'
+LOG_DIR = '<%= scope.lookupvar('graphite::gr_graphiteweb_log_dir') %>'
 #INDEX_FILE = '/opt/graphite/storage/index'  # Search index file
 
 


### PR DESCRIPTION
This should provide functionality to support FHS/custom paths.

Also addresses issue #171

happy to receive any feedback!

example config:
 class { 'graphite':
    gr_line_receiver_port          => 2003,
    gr_pickle_receiver_port        => 2004,
    gr_cache_query_port            => 7002,
    gr_cache_instances             => {
      'cache:b'              => {
        'LINE_RECEIVER_PORT'   => 2103,
        'PICKLE_RECEIVER_PORT' => 2104,
        'CACHE_QUERY_PORT'     => 7102,
      }
      ,
      'cache:c'              => {
        'LINE_RECEIVER_PORT'   => 2203,
        'PICKLE_RECEIVER_PORT' => 2204,
        'CACHE_QUERY_PORT'     => 7202,
      }
    }
    ,
    gr_base_dir                    => '/opt/carbon',
    gr_storage_dir                 => '/opt/carbon',
    gr_graphiteweb_log_dir         => '/var/log/graphite-web',
    gr_carbon_conf_dir             => '/etc/carbon',
    gr_carbon_log_dir              => '/var/log/carbon',
    gr_graphiteweb_conf_dir        => '/etc/graphite-web',
    gr_graphiteweb_storage_dir     => '/var/lib/graphite-web',
    gr_graphiteweb_webapp_dir      => '/usr/share/graphite/webapp',
    gr_graphiteweb_install_lib_dir => '/usr/lib/python2.7/site-packages/graphite',
    gr_pip_install                 => false,
    gr_twisted_pkg                 => 'python-twisted-core',
    gr_twisted_ver                 => 'latest',
    gr_txamqp_pkg                  => 'python-txamqp',
    gr_txamqp_ver                  => 'absent',
    #  gr_graphite_pkg => 'graphite-web',
    gr_graphite_ver                => 'latest',
    gr_carbon_pkg                  => 'python-carbon',
    gr_carbon_ver                  => 'latest',
    gr_whisper_pkg                 => 'python-whisper',
    gr_whisper_ver                 => 'latest',
    gr_django_pkg                  => 'python-django',
    gr_django_ver                  => 'latest',
    gr_django_provider             => 'yum',
    gr_django_tagging_pkg          => 'python-django-tagging',
    gr_django_tagging_ver          => 'latest',
    gr_web_cors_allow_from_all     => true,
    gr_apache_logdir               => '/var/log/httpd',
    gr_django_db_name              => '/var/lib/graphite-web/graphite.db',
  }


