### PR TITLE
fix python2-crypto package on CentOS7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,7 +89,6 @@ class graphite::params {
         'MySQL-python',
         'pyOpenSSL',
         'pycairo',
-        'python-crypto',
         'python-ldap',
         'python-memcached',
         'python-psycopg2',
@@ -102,13 +101,13 @@ class graphite::params {
         /^6\.\d+$/: {
           $apache_24    = false
           $django_pkg = 'Django14'
-          $graphitepkgs = union($common_os_pkgs,['python-sqlite2','bitmap-fonts-compat','bitmap'])
+          $graphitepkgs = union($common_os_pkgs,['python-sqlite2','bitmap-fonts-compat','bitmap','python-crypto'])
         }
 
         /^7\.\d+/: {
           $apache_24    = true
           $django_pkg = 'python-django'
-          $graphitepkgs = union($common_os_pkgs,['python-sqlite3dbm','dejavu-fonts-common','dejavu-sans-fonts'])
+          $graphitepkgs = union($common_os_pkgs,['python-sqlite3dbm','dejavu-fonts-common','dejavu-sans-fonts','python2-crypto',])
         }
 
         default: {

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -63,7 +63,6 @@ describe 'graphite::install', :type => 'class' do
     it { should contain_package('MySQL-python').with_provider(nil) }
     it { should contain_package('pyOpenSSL').with_provider(nil) }
     it { should contain_package('pycairo').with_provider(nil) }
-    it { should contain_package('python-crypto').with_provider(nil) }
     it { should contain_package('python-memcached').with_provider(nil) }
     it { should contain_package('python-zope-interface').with_provider(nil) }
   end
@@ -73,6 +72,7 @@ describe 'graphite::install', :type => 'class' do
     it { should contain_package('python-sqlite2').with_provider(nil) }
     it { should contain_package('bitmap').with_provider(nil) }
     it { should contain_package('bitmap-fonts-compat').with_provider(nil) }
+    it { should contain_package('python-crypto').with_provider(nil) }
 
     it { should contain_file('carbon_hack').only_with(hack_defaults.merge({
       :target => '/opt/graphite/lib/carbon-0.9.15-py2.6.egg-info',
@@ -89,6 +89,7 @@ describe 'graphite::install', :type => 'class' do
     it { should contain_package('python-sqlite3dbm').with_provider(nil) }
     it { should contain_package('dejavu-fonts-common').with_provider(nil) }
     it { should contain_package('dejavu-sans-fonts').with_provider(nil) }
+    it { should contain_package('python2-crypto').with_provider(nil) }
 
     it { should contain_file('carbon_hack').only_with(hack_defaults.merge({
       :target => '/opt/graphite/lib/carbon-0.9.15-py2.7.egg-info',


### PR DESCRIPTION
Title says it.
On CentOS 7 (7.2) at least, python-crypto has been obsoleted by python2-crypto from epel, and every puppet runs which tries to install python-crypto will trigger many class and exec refreshes like this : 

```
Notice: /Stage[main]/Graphite::Install/Package[python-crypto]/ensure: created
Info: Class[Graphite::Install]: Scheduling refresh of Class[Graphite::Config]
Info: Class[Graphite::Install]: Scheduling refresh of Exec[Initial django db creation]
Info: Class[Graphite::Config]: Scheduling refresh of Exec[Initial django db creation]
Info: Class[Graphite::Config]: Scheduling refresh of Service[carbon-cache]
```

Because of :

```
 # yum install python-crypto 
Loaded plugins: fastestmirror, langpacks
Loading mirror speeds from cached hostfile
Package python-crypto-2.6.1-1.el7.centos.x86_64 is obsoleted by python2-crypto-2.6.1-9.el7.x86_64 which is already installed
Nothing to do

##
Installed Packages
python2-crypto.x86_64                              2.6.1-9.el7                               @epel
```


Please note I'm not sure about the install_spec.rb test, as I'm a complete noob with these tests (only "bundle exec rake spec" seems unhappy, but not specifically about that change)

Regards