### PR TITLE
additions to init scripts to put PIDs in pidfiles

### DIFF
--- a/templates/etc/init.d/RedHat/carbon-aggregator.erb
+++ b/templates/etc/init.d/RedHat/carbon-aggregator.erb
@@ -49,6 +49,7 @@ start()
         sleep 1
         if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
+            ps -ef | grep carbon-${CARBON_DAEMON} | grep -v grep | tr -s [:space:] | cut -f 2 -d ' ' | head -1 > $pidfile
             echo_success
             echo
         else

--- a/templates/etc/init.d/RedHat/carbon-cache.erb
+++ b/templates/etc/init.d/RedHat/carbon-cache.erb
@@ -49,6 +49,7 @@ start()
         sleep 1
         if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
+	    ps -ef | grep carbon-${CARBON_DAEMON} | grep -v grep | tr -s [:space:] | cut -f 2 -d ' ' | head -1 > $pidfile
             echo_success
             echo
         else

--- a/templates/etc/init.d/RedHat/carbon-cache.erb
+++ b/templates/etc/init.d/RedHat/carbon-cache.erb
@@ -49,7 +49,7 @@ start()
         sleep 1
         if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
-	    ps -ef | grep carbon-${CARBON_DAEMON} | grep -v grep | tr -s [:space:] | cut -f 2 -d ' ' | head -1 > $pidfile
+            ps -ef | grep carbon-${CARBON_DAEMON} | grep -v grep | tr -s [:space:] | cut -f 2 -d ' ' | head -1 > $pidfile
             echo_success
             echo
         else

--- a/templates/etc/init.d/RedHat/carbon-relay.erb
+++ b/templates/etc/init.d/RedHat/carbon-relay.erb
@@ -49,6 +49,7 @@ start()
         sleep 1
         if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
+	    ps -ef | grep carbon-${CARBON_DAEMON} | grep -v grep | tr -s [:space:] | cut -f 2 -d ' ' | head -1 > $pidfile
             echo_success
             echo
         else

--- a/templates/etc/init.d/RedHat/carbon-relay.erb
+++ b/templates/etc/init.d/RedHat/carbon-relay.erb
@@ -49,7 +49,7 @@ start()
         sleep 1
         if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
-	    ps -ef | grep carbon-${CARBON_DAEMON} | grep -v grep | tr -s [:space:] | cut -f 2 -d ' ' | head -1 > $pidfile
+            ps -ef | grep carbon-${CARBON_DAEMON} | grep -v grep | tr -s [:space:] | cut -f 2 -d ' ' | head -1 > $pidfile
             echo_success
             echo
         else


### PR DESCRIPTION
We use monit, and I suspect a lot of other people do also, and it assumes the process didn't start correctly if the pidfile doesn't have the pid of the process in it. Adding a one-liner to each carbon service's init file to populate the pid files with the pid number.