### PR TITLE
Add sleep to restart command to match start

### DIFF
--- a/templates/etc/init.d/RedHat/carbon-relay.erb
+++ b/templates/etc/init.d/RedHat/carbon-relay.erb
@@ -112,6 +112,7 @@ restart() {
         retval=$?
         pidfile=${GRAPHITE_DIR}/storage/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         echo -n $"Starting carbon-${CARBON_DAEMON}:${INSTANCE}..."
+        sleep 1
         if rh_status_q; then
             touch /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
             echo_success


### PR DESCRIPTION
Fixes an issue where restart returns failed even though process has started successfully.