### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ apache::vhost { graphite.my.domain:
     display-name       => '%{GROUP}',
     inactivity-timeout => '120',
   },
-  wsgi_import_script          => '/opt/graphite/conf/graphite.wsgi',
+  wsgi_import_script          => '/opt/graphite/conf/graphite_wsgi.py',
   wsgi_import_script_options  => {
     process-group     => 'graphite',
     application-group => '%{GLOBAL}'
   },
   wsgi_process_group          => 'graphite',
   wsgi_script_aliases         => {
-    '/' => '/opt/graphite/conf/graphite.wsgi'
+    '/' => '/opt/graphite/conf/graphite_wsgi.py'
   },
   headers => [
     'set Access-Control-Allow-Origin "*"',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,6 +37,7 @@ class graphite::config inherits graphite::params {
       $gr_web_group_REAL = pick($::graphite::gr_web_group, $::graphite::params::apache_web_group)
       include graphite::config_apache
       $web_server_package_require = [Package[$::graphite::params::apache_pkg]]
+      $web_server_service_notify  = Service[$::graphite::params::apache_service_name]
     }
 
     'nginx'    : {
@@ -46,6 +47,7 @@ class graphite::config inherits graphite::params {
       include graphite::config_gunicorn
       include graphite::config_nginx
       $web_server_package_require = [Package['nginx']]
+      $web_server_service_notify  = Service['gunicorn']
     }
 
     'wsgionly' : {
@@ -57,6 +59,7 @@ class graphite::config inherits graphite::params {
       $gr_web_group_REAL = pick($::graphite::gr_web_group)
       include graphite::config_gunicorn
       $web_server_package_require = undef
+      $web_server_service_notify  = Service['gunicorn']
     }
 
     'none'     : {
@@ -67,6 +70,7 @@ class graphite::config inherits graphite::params {
       $gr_web_user_REAL = pick($::graphite::gr_web_user)
       $gr_web_group_REAL = pick($::graphite::gr_web_group)
       $web_server_package_require = undef
+      $web_server_service_notify  = undef
     }
 
     default    : {
@@ -160,7 +164,8 @@ class graphite::config inherits graphite::params {
       group   => $gr_web_group_REAL,
       mode    => '0644',
       owner   => $gr_web_user_REAL,
-      require => $web_server_package_require;
+      require => $web_server_package_require,
+      notify  => $web_server_service_notify;
 
     "${::graphite::graphiteweb_conf_dir_REAL}/graphite_wsgi.py":
       ensure  => file,
@@ -168,7 +173,8 @@ class graphite::config inherits graphite::params {
       group   => $gr_web_group_REAL,
       mode    => '0644',
       owner   => $gr_web_user_REAL,
-      require => $web_server_package_require;
+      require => $web_server_package_require,
+      notify  => $web_server_service_notify;
 
     "${::graphite::graphiteweb_install_lib_dir_REAL}/graphite_wsgi.py":
       ensure  => link,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -109,6 +109,7 @@ class graphite::config inherits graphite::params {
     $::graphite::rrd_dir_REAL,
     $::graphite::whitelists_dir_REAL,
     $::graphite::graphiteweb_log_dir_REAL,
+    $::graphite::graphiteweb_storage_dir_REAL,
     $::graphite::gr_pid_dir,
     "${::graphite::base_dir_REAL}/bin"]:
     ensure    => directory,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,7 +17,8 @@ class graphite::config inherits graphite::params {
   # optional:  python-ldap, python-memcache, memcached, python-sqlite
 
   if ($::graphite::params::service_provider == 'redhat' and $::operatingsystemrelease =~ /^7\.\d+/) or (
-  $::graphite::params::service_provider == 'debian' and $::operatingsystemmajrelease =~ /8|15\.10/) {
+  $::graphite::params::service_provider == 'debian' and $::operatingsystemmajrelease =~ /8|15\.10/) or (
+  $::graphite::params::service_provider == 'systemd') {
     $initscript_notify = [Exec['graphite-reload-systemd'],]
 
     exec { 'graphite-reload-systemd':

--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -120,7 +120,7 @@ class graphite::config_apache inherits graphite::params {
       mode    => '0644',
       owner   => $::graphite::config::gr_web_user_REAL,
       require => [
-        File[$::graphite::gr_storage_dir],
+        File[$::graphite::storage_dir_REAL],
         File["${::graphite::params::apache_dir}/ports.conf"],
       ],
       notify  => Service[$::graphite::params::apache_service_name];

--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -61,6 +61,15 @@ class graphite::config_apache inherits graphite::params {
     }
   }
 
+  # Create the log dir if it doesn't exist
+  file { $::graphite::gr_apache_logdir:
+      ensure  => directory,
+      group   => $::graphite::config::gr_web_group_REAL,
+      mode    => '0644',
+      owner   => $::graphite::config::gr_web_user_REAL,
+      require => Package[$::graphite::params::apache_pkg],
+  }
+
   # fix graphite's race condition on start
   # if the exec fails, assume we're using a version of graphite that doesn't need it
   file { '/tmp/fix-graphite-race-condition.py':

--- a/manifests/config_gunicorn.pp
+++ b/manifests/config_gunicorn.pp
@@ -85,16 +85,6 @@ class graphite::config_gunicorn inherits graphite::params {
 
   }
 
-  # The `gunicorn-debian` command doesn't require this, as it
-  # uses the deprecated `gunicorn_django` command. But, I hope
-  # that debian will eventually update their gunicorn package
-  # to use the non-deprecated version.
-  file { "${graphite::graphiteweb_install_lib_dir_REAL}/wsgi.py":
-    ensure => link,
-    target => "${graphite::graphiteweb_conf_dir_REAL}/graphite.wsgi",
-    before => Service['gunicorn'],
-  }
-
   # fix graphite's race condition on start
   # if the exec fails, assume we're using a version of graphite that doesn't need it
   if $graphite::gunicorn_workers > 1 {
@@ -138,9 +128,7 @@ class graphite::config_gunicorn inherits graphite::params {
     hasstatus  => false,
     require    => [
       Package[$package_name],
-      File["${::graphite::graphiteweb_conf_dir_REAL}/graphite_wsgi.py"]
     ],
-    subscribe  => File[$::graphite::config::local_settings_py_file],
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -672,7 +672,7 @@ class graphite (
   $gr_graphiteweb_storage_dir             = '/var/lib/graphite-web',
   $gr_graphiteweb_install_lib_dir         = undef,
   $gr_pid_dir                             = '/var/run',
-  $gr_apache_logdir                       = '/var/log/httpd/graphite-web',
+  $gr_apache_logdir                       = $::graphite::params::apache_logdir_graphite,
   $gunicorn_arg_timeout                   = 30,
   $gunicorn_bind                          = 'unix:/var/run/graphite.sock',
   $gunicorn_workers                       = 2,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,7 +48,7 @@ class graphite::params {
       $apacheconf_dir            = '/etc/apache2/sites-available'
       $apacheports_file          = 'ports.conf'
       $apache_logdir_graphite    = '/var/log/apache2/graphite-web'
-      $service_provider          = undef
+      $service_provider          = $::service_provider
 
       $nginxconf_dir    = '/etc/nginx/sites-available'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,7 +48,7 @@ class graphite::params {
       $apacheconf_dir            = '/etc/apache2/sites-available'
       $apacheports_file          = 'ports.conf'
       $apache_logdir_graphite    = '/var/log/apache2/graphite-web'
-      $service_provider          = $::service_provider
+      $service_provider          = 'debian'
 
       $nginxconf_dir    = '/etc/nginx/sites-available'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,6 +47,7 @@ class graphite::params {
       $apache_wsgi_socket_prefix = '/var/run/apache2/wsgi'
       $apacheconf_dir            = '/etc/apache2/sites-available'
       $apacheports_file          = 'ports.conf'
+      $apache_logdir_graphite    = '/var/log/apache2/graphite-web'
       $service_provider          = undef
 
       $nginxconf_dir    = '/etc/nginx/sites-available'
@@ -94,6 +95,7 @@ class graphite::params {
       $apache_wsgi_socket_prefix = 'run/wsgi'
       $apacheconf_dir            = '/etc/httpd/conf.d'
       $apacheports_file          = 'graphite_ports.conf'
+      $apache_logdir_graphite    = '/var/log/httpd/graphite-web'
       $service_provider          = 'redhat'
 
       $nginxconf_dir    = '/etc/nginx/conf.d'

--- a/templates/etc/apache2/sites-available/graphite.conf.erb
+++ b/templates/etc/apache2/sites-available/graphite.conf.erb
@@ -30,11 +30,11 @@ WSGISocketPrefix <%= scope.lookupvar('graphite::params::apache_wsgi_socket_prefi
 	WSGIDaemonProcess graphite processes=<%= scope.lookupvar('graphite::wsgi_processes') -%> threads=<%= scope.lookupvar('graphite::wsgi_threads') -%> display-name='%{GROUP}' inactivity-timeout=<%= scope.lookupvar('graphite::wsgi_inactivity_timeout') %>
 	WSGIProcessGroup graphite
 	WSGIApplicationGroup %{GLOBAL}
-	WSGIImportScript <%= scope.lookupvar('graphite::graphiteweb_conf_dir_REAL') %>/graphite.wsgi process-group=graphite application-group=%{GLOBAL}
+	WSGIImportScript <%= scope.lookupvar('graphite::graphiteweb_conf_dir_REAL') %>/graphite_wsgi.py process-group=graphite application-group=%{GLOBAL}
 
 	# XXX You will need to create this file! There is a graphite.wsgi.example
 	# file in this directory that you can safely use, just copy it to graphite.wgsi
-	WSGIScriptAlias / <%= scope.lookupvar('graphite::graphiteweb_conf_dir_REAL') %>/graphite.wsgi
+	WSGIScriptAlias / <%= scope.lookupvar('graphite::graphiteweb_conf_dir_REAL') %>/graphite_wsgi.py
 
 	Alias /content/ <%= scope.lookupvar('graphite::graphiteweb_webapp_dir_REAL') %>/content/
 	<Location "/content/">

--- a/templates/etc/init.d/RedHat/gunicorn.erb
+++ b/templates/etc/init.d/RedHat/gunicorn.erb
@@ -31,7 +31,7 @@ ENV=production
 start() {
     echo -n $"Starting $prog: "
     cd $APP_ROOT
-    gunicorn --pid $pidfile --daemon graphite.graphite_wsgi:application --timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %> --bind=<%= scope.lookupvar('graphite::gunicorn_bind') %> --workers=<%= scope.lookupvar('graphite::gunicorn_workers') %> --user <%= scope.lookupvar('graphite::config::gr_web_user_REAL') %> --group <%= scope.lookupvar('graphite::config::gr_web_group_REAL') %> --chdir /opt/graphite/webapp/ --access-logfile <%= scope.lookupvar('graphite::graphiteweb_log_dir_REAL') %>/access-gunicorn.log --error-logfile /<%= scope.lookupvar('graphite::graphiteweb_log_dir_REAL') %>/error-gunicorn.log
+    gunicorn --pid $pidfile --daemon graphite.graphite_wsgi:application --timeout=<%= scope.lookupvar('graphite::gunicorn_arg_timeout') %> --bind=<%= scope.lookupvar('graphite::gunicorn_bind') %> --workers=<%= scope.lookupvar('graphite::gunicorn_workers') %> --user <%= scope.lookupvar('graphite::config::gr_web_user_REAL') %> --group <%= scope.lookupvar('graphite::config::gr_web_group_REAL') %> --chdir $APP_ROOT --access-logfile <%= scope.lookupvar('graphite::graphiteweb_log_dir_REAL') %>/access-gunicorn.log --error-logfile /<%= scope.lookupvar('graphite::graphiteweb_log_dir_REAL') %>/error-gunicorn.log
     RETVAL=$?
     echo -n
     [ $RETVAL = 1 ] && echo -e '[\e[31m FAILED \e[m]'


### PR DESCRIPTION
I am basically just repeating the git commit logs, but here we go:
- Ensure log directory, make OS-agnostic
- Fix old parameter usage (I believe you already fixed this)
- Update Apache's `graphite.conf` template to point to `graphite_wsgi.py`
- Update README to reflect this
- Ensure `graphiteweb_storage_dir_REAL` directory
- Remove old `wsgi.py` link for gunicorn (no longer needed)
- Notify web server on changes to `local_settings.py` and `graphite_wsgi.py`
- Properly parameterize `--chdir` in gunicorn `init.d` file
- Add missing `service_provider` for debian
- Add case for `$::service_provider == 'systemd'` in `config.pp`