### PR TITLE
Use proper dependencies for race condition fix

### DIFF
--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -89,7 +89,9 @@ class graphite::config_apache inherits graphite::params {
     refreshonly => true,
     require     => [
       File['/tmp/fix-graphite-race-condition.py'],
-      Service['carbon-cache'],
+      File[$::graphite::storage_dir_REAL],
+      File[$::graphite::graphiteweb_log_dir_REAL],
+      File[$::graphite::graphiteweb_storage_dir_REAL],
     ],
     before      => Service[$::graphite::params::apache_service_name],
     subscribe   => Exec['Initial django db creation'],

--- a/manifests/config_gunicorn.pp
+++ b/manifests/config_gunicorn.pp
@@ -108,7 +108,9 @@ class graphite::config_gunicorn inherits graphite::params {
       refreshonly => true,
       require     => [
         File['/tmp/fix-graphite-race-condition.py'],
-        Service['carbon-cache'],
+        File[$::graphite::storage_dir_REAL],
+        File[$::graphite::graphiteweb_log_dir_REAL],
+        File[$::graphite::graphiteweb_storage_dir_REAL],
       ],
       before      => Package[$package_name],
       subscribe   => Exec['Initial django db creation'],


### PR DESCRIPTION
The race condition fix is related strictly to the webapp, and not to carbon. This fix changes the `require` for the race condition fix from `Service[carbon-cache]` to the minimum dependencies required to run the fix on the webapp.

Fixes #245.