### PR TITLE
In order to avoid ==> default: Error: Could not find dependency Packa…

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -46,7 +46,9 @@ class graphite::install inherits graphite::params {
   #           python-django-tagging, python-simplejson
   # optional: python-ldap, python-memcache, memcached, python-sqlite
 
-  ensure_packages($::graphite::params::graphitepkgs)
+  ensure_packages($::graphite::params::graphitepkgs, {
+      before => Package['carbon']
+  })
 
   create_resources('package', {
     'carbon'         => {


### PR DESCRIPTION
In order to avoid ==> default: Error: Could not find dependency Package[python-ldap] for Package[carbon]