### PR TITLE
fix graphite.db permissions & location & remove default apache config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -147,7 +147,7 @@ class graphite::config inherits graphite::params {
   }
 
   # Lets ensure graphite.db owner is the same as gr_web_user_REAL
-  file { "${::graphite::storage_dir_REAL}/graphite.db":
+  file { "${::graphite::graphiteweb_storage_dir_REAL}/graphite.db":
     ensure => file,
     group  => $gr_web_group_REAL,
     mode   => '0644',

--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -129,6 +129,11 @@ class graphite::config_apache inherits graphite::params {
         File["${::graphite::params::apache_dir}/ports.conf"],
       ],
       notify  => Service[$::graphite::params::apache_service_name];
+      
+      # If installing from package the default vhost config file needs removing
+    "${::graphite::params::apacheconf_dir}/graphite_web.conf":
+      ensure  => absent,
+      notify  => Service[$::graphite::params::apache_service_name];
   }
 
   case $::osfamily {


### PR DESCRIPTION
Apologies - I haven't had chance to do any more to this since the last commit, until now!

if installing from packages you get a default apache config -
graphite_web.conf. However, that has data in it which stops httpd from
starting therefore ensuring it's removed here as this module creates a
graphite.conf.

correcting the value of graphite.db's directory, to ensure that the
permissions are set on the correct file - in the case where the packages
set one up in /var/lib/graphite-web/graphite.db, and you specify this
value for the django backend name
