### PR TITLE
Add support for Amazon Linux

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,7 +13,7 @@ class graphite::install inherits graphite::params {
   }
 
   if $::graphite::gr_pip_install and $::osfamily == 'RedHat' {
-    validate_re($::operatingsystemrelease, '^[6-7]\.\d+', "Unsupported RedHat release: '${::operatingsystemrelease}'")
+    validate_re($::operatingsystemrelease, '^[6-7]\.\d+|^20\d{2}.\d{2}', "Unsupported RedHat release: '${::operatingsystemrelease}'")
   }
 
   # # Set class variables

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,6 @@
 class graphite::params {
   $build_dir = '/usr/local/src/'
 
-  $python_pip_pkg     = 'python-pip'
   $django_tagging_pkg = 'django-tagging'
   $django_tagging_ver = '0.3.1'
   $twisted_pkg        = 'Twisted'
@@ -40,6 +39,7 @@ class graphite::params {
   }
   case $::osfamily {
     'Debian': {
+      $python_pip_pkg            = 'python-pip'
       $apache_dir                = '/etc/apache2'
       $apache_pkg                = 'apache2'
       $apache_service_name       = 'apache2'
@@ -122,11 +122,13 @@ class graphite::params {
         $pyopenssl       = "${python}-pyOpenSSL"
         $apache_wsgi_pkg = "mod_wsgi-${python}"
         $pytz            = "${python}-pytz"
+        $python_pip_pkg  = "${python}-pip"
       } else {
         $python          = 'python'
         $pyopenssl       = 'pyOpenSSL'
         $apache_wsgi_pkg = 'mod_wsgi'
         $pytz            = 'python-tzlocal'
+        $python_pip_pkg  = 'python-pip'
       }
 
       $python_dev_pkg = ["${python}-devel", 'gcc']
@@ -143,22 +145,22 @@ class graphite::params {
       # see https://github.com/graphite-project/carbon/issues/86
       case $::operatingsystemrelease {
         /^6\.\d+$/: {
-          $apache_24           = false
-          $graphitepkgs        = union($common_os_pkgs,['python-sqlite2', 'bitmap-fonts-compat', 'bitmap', 'pycairo','python-crypto'])
-          $service_provider    = 'redhat'
+          $apache_24        = false
+          $graphitepkgs     = union($common_os_pkgs,['python-sqlite2', 'bitmap-fonts-compat', 'bitmap', 'pycairo','python-crypto'])
+          $service_provider = 'redhat'
         }
 
         /^7\.\d+/: {
-          $apache_24           = true
-          $graphitepkgs        = union($common_os_pkgs,['python-sqlite3dbm', 'dejavu-fonts-common', 'dejavu-sans-fonts', 'python-cairocffi','python2-crypto'])
-          $service_provider    = 'systemd'
+          $apache_24        = true
+          $graphitepkgs     = union($common_os_pkgs,['python-sqlite3dbm', 'dejavu-fonts-common', 'dejavu-sans-fonts', 'python-cairocffi','python2-crypto'])
+          $service_provider = 'systemd'
         }
 
         # Amazon Linux 20xx.xx
         /^20\d{2}.\d{2}/: {
-          $apache_24           = false
-          $graphitepkgs        = union($common_os_pkgs,['bitmap', "${python}-pycairo","${python}-crypto"])
-          $service_provider    = 'redhat'
+          $apache_24        = false
+          $graphitepkgs     = union($common_os_pkgs,['bitmap', "${python}-pycairo","${python}-crypto"])
+          $service_provider = 'redhat'
         }
 
         default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -104,7 +104,6 @@ class graphite::params {
       $apache_dir                = '/etc/httpd'
       $apache_pkg                = 'httpd'
       $apache_service_name       = 'httpd'
-      $apache_wsgi_pkg           = 'mod_wsgi'
       $apache_wsgi_socket_prefix = 'run/wsgi'
       $apacheconf_dir            = '/etc/httpd/conf.d'
       $apacheports_file          = 'graphite_ports.conf'
@@ -118,11 +117,14 @@ class graphite::params {
       $nginx_web_user   = 'nginx'
 
       if $::operatingsystem =~ /^[Aa]mazon$/ {
-        $python    = 'python27'
-        $pyopenssl = "${python}-pyOpenSSL"
+        $_pyver          = regsubst($pyver, '.', '')
+        $python          = "python${_pyver}"
+        $pyopenssl       = "${python}-pyOpenSSL"
+        $apache_wsgi_pkg = "mod_wsgi-${python}"
       } else {
-        $python    = 'python'
-        $pyopenssl = 'pyOpenSSL'
+        $python          = 'python'
+        $pyopenssl       = 'pyOpenSSL'
+        $apache_wsgi_pkg = 'mod_wsgi'
       }
 
       $python_dev_pkg = ["${python}-devel", 'gcc']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -117,7 +117,7 @@ class graphite::params {
       $nginx_web_user   = 'nginx'
 
       if $::operatingsystem =~ /^[Aa]mazon$/ {
-        $_pyver          = regsubst($pyver, '.', '')
+        $_pyver          = regsubst($pyver, '\.', '')
         $python          = "python${_pyver}"
         $pyopenssl       = "${python}-pyOpenSSL"
         $apache_wsgi_pkg = "mod_wsgi-${python}"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -153,7 +153,7 @@ class graphite::params {
         # Amazon Linux 2016.03
         /^20\d{2}.\d{2}/: {
           $apache_24           = false
-          $graphitepkgs        = union($common_os_pkgs,["${python}-sqlite2", 'bitmap', "${python}-pycairo","${python}-crypto"])
+          $graphitepkgs        = union($common_os_pkgs,["python-sqlite2", 'bitmap', "${python}-pycairo","${python}-crypto"])
           $service_provider    = 'redhat'
         }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -117,15 +117,23 @@ class graphite::params {
       $nginx_web_group  = 'nginx'
       $nginx_web_user   = 'nginx'
 
-      $python_dev_pkg = ['python-devel','gcc']
+      if $::operatingsystem =~ /^[Aa]mazon$/ {
+        $python    = 'python27'
+        $pyopenssl = "${python}-pyOpenSSL"
+      } else {
+        $python    = 'python'
+        $pyopenssl = 'pyOpenSSL'
+      }
+
+      $python_dev_pkg = ["${python}-devel", 'gcc']
       $common_os_pkgs = [
-        'MySQL-python',
-        'pyOpenSSL',
-        'python-ldap',
-        'python-memcached',
-        'python-psycopg2',
-        'python-zope-interface',
-        'python-tzlocal',
+        "MySQL-${python}",
+        $pyopenssl,
+        "${python}-ldap",
+        "${python}-memcached",
+        "${python}-psycopg2",
+        "${python}-zope-interface",
+        "python-tzlocal",
       ]
 
       # see https://github.com/graphite-project/carbon/issues/86
@@ -142,10 +150,18 @@ class graphite::params {
           $service_provider    = 'systemd'
         }
 
+        # Amazon Linux 2016.03
+        /^20\d{2}.\d{2}/: {
+          $apache_24           = false
+          $graphitepkgs        = union($common_os_pkgs,["${python}-sqlite2", 'bitmap', "${python}-pycairo","${python}-crypto"])
+          $service_provider    = 'redhat'
+        }
+
         default: {
           fail("Unsupported RedHat release: '${::operatingsystemrelease}'")
         }
       }
+
       $libpath = "/usr/lib/python${pyver}/site-packages"
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -152,10 +152,10 @@ class graphite::params {
           $service_provider    = 'systemd'
         }
 
-        # Amazon Linux 2016.03
+        # Amazon Linux 20xx.xx
         /^20\d{2}.\d{2}/: {
           $apache_24           = false
-          $graphitepkgs        = union($common_os_pkgs,["python-sqlite2", 'bitmap', "${python}-pycairo","${python}-crypto"])
+          $graphitepkgs        = union($common_os_pkgs,['bitmap', "${python}-pycairo","${python}-crypto"])
           $service_provider    = 'redhat'
         }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -121,10 +121,12 @@ class graphite::params {
         $python          = "python${_pyver}"
         $pyopenssl       = "${python}-pyOpenSSL"
         $apache_wsgi_pkg = "mod_wsgi-${python}"
+        $pytz            = "${python}-pytz"
       } else {
         $python          = 'python'
         $pyopenssl       = 'pyOpenSSL'
         $apache_wsgi_pkg = 'mod_wsgi'
+        $pytz            = 'python-tzlocal'
       }
 
       $python_dev_pkg = ["${python}-devel", 'gcc']
@@ -135,7 +137,7 @@ class graphite::params {
         "${python}-memcached",
         "${python}-psycopg2",
         "${python}-zope-interface",
-        "python-tzlocal",
+        $pytz,
       ]
 
       # see https://github.com/graphite-project/carbon/issues/86

--- a/metadata.json
+++ b/metadata.json
@@ -53,6 +53,14 @@
         "14.04",
         "15.10"
       ]
+    },
+    {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": [
+        "2016.03",
+        "2015.09",
+        "2015.03"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
Added package dependencies to install Graphite in Amazon Linux. I've only tested it with AMI 2016.03 however since the release of the AMI 2015.03[1] Python 2.7 is the default version so it must work since then.

[1] https://aws.amazon.com/amazon-linux-ami/2015.03-release-notes/