### PR TITLE
Fix empty CARBONLINK_HOSTS

### DIFF
--- a/templates/opt/graphite/webapp/graphite/local_settings.py.erb
+++ b/templates/opt/graphite/webapp/graphite/local_settings.py.erb
@@ -258,7 +258,7 @@ REMOTE_RENDER_CONNECT_TIMEOUT = <%= scope.lookupvar('graphite::gr_rendering_host
 #
 # You *should* use 127.0.0.1 here in most cases
 <% if [:undef, nil].include? scope.lookupvar('graphite::gr_carbonlink_hosts') -%>
-#CARBONLINK_HOSTS = ["127.0.0.1:7002:a", "127.0.0.1:7102:b", "127.0.0.1:7202:c"]
+CARBONLINK_HOSTS = []
 #CARBONLINK_TIMEOUT = 1.0
 <% else -%>
 CARBONLINK_HOSTS = ['<%= scope.lookupvar('graphite::gr_carbonlink_hosts').join("','") %>']


### PR DESCRIPTION
Hello, 

According to this bug, it is better to provide an empty array to avoid this issue :

https://answers.launchpad.net/graphite/+question/275265

Regards

Olivier