### PR TITLE
Avoid conflicts in common packages

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -46,14 +46,13 @@ class graphite::install inherits graphite::params {
   #           python-django-tagging, python-simplejson
   # optional: python-ldap, python-memcache, memcached, python-sqlite
 
-  ensure_packages($::graphite::params::graphitepkgs, {
-      before => Package['carbon']
-  })
+  ensure_packages($::graphite::params::graphitepkgs)
 
   create_resources('package', {
-    'carbon'         => {
-      ensure => $::graphite::gr_carbon_ver,
-      name   => $::graphite::gr_carbon_pkg,
+    'carbon'  => {
+      ensure  => $::graphite::gr_carbon_ver,
+      name    => $::graphite::gr_carbon_pkg,
+      require => Package[$::graphite::params::graphitepkgs],
     }
     ,
     'django-tagging' => {


### PR DESCRIPTION
I ran into a scenario where I had two modules calling `ensure_packages`
with `python-simplejson`. The extra parameters that this module added
to the resource caused a conflict. This PR moves the extra parameters
to avoid the conflict.
