### PR TITLE
Fix package dependency issue with RH7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -124,7 +124,6 @@ class graphite::params {
         'python-ldap',
         'python-memcached',
         'python-psycopg2',
-        'python-zope-interface',
         'python-tzlocal',
       ]
 
@@ -132,7 +131,7 @@ class graphite::params {
       case $::operatingsystemrelease {
         /^6\.\d+$/: {
           $apache_24           = false
-          $graphitepkgs        = union($common_os_pkgs,['python-sqlite2', 'bitmap-fonts-compat', 'bitmap', 'pycairo','python-crypto'])
+          $graphitepkgs        = union($common_os_pkgs,['python-sqlite2', 'bitmap-fonts-compat', 'bitmap', 'pycairo', 'python-crypto','python-zope-interface',])
           $service_provider    = 'redhat'
         }
 


### PR DESCRIPTION
The package python-zope-interface is listed as being removed from RH7

https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Migration_Planning_Guide/sect-Red_Hat_Enterprise_Linux-Migration_Planning_Guide-Removed_Packages.html

I have moved this from the RH common packages to RH 6 
This resolves the package dependency issue and allow the module to run on RH7
 
There is no replacement package listed for this, so i have nothing to replace it with. So far i have not encountered any issues with deploying to RH7 without this package. 