### PR TITLE
Use http URL for stdlib Fixture

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,5 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     graphite: "#{source_dir}"


### PR DESCRIPTION
Minor change which prevents clones from failing due to blocked SSH connections or incorrectly set up SSH keys for GitHub. This is one of the obstacles I encountered while trying to run the tests on my machine.