### PR TITLE
Ignore variables with uppercase letters in lint

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 PuppetLint.configuration.send('disable_class_parameter_defaults')
 PuppetLint.configuration.send('disable_documentation')
 PuppetLint.configuration.send('disable_single_quote_string_with_variables')
+PuppetLint.configuration.send('disable_variable_is_lowercase')
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Validate manifests, templates, and ruby files in lib."


### PR DESCRIPTION
This module uses lots of variable names postfixed with '_REAL'. Assuming that is a practice you wish to continue, it'd probably be a good idea to remove this lint rule.

Disables the following warning:

    <file> - WARNING: variable contains an uppercase letter on line <linenumber>