### PR TITLE
Require pip before installing Django

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -98,6 +98,7 @@ class graphite::install inherits graphite::params {
       ensure   => $::graphite::gr_django_ver,
       provider => $::graphite::gr_django_provider,
       source   => $::graphite::gr_django_source,
+      require  => $gr_pkg_require,
     }
   }
 


### PR DESCRIPTION
The provider for the Django package is pip by default, but the Django package resource currently isn't set to require `pip`, which can lead to an error when pip is not already installed on the target system and Puppet decides to try to install Django before installing pip. This commit fixes that issue.