### PR TITLE
Allow setting service provider by parameter

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,7 +16,7 @@ class graphite::config inherits graphite::params {
   #            python-django-tagging, python-simplejson
   # optional:  python-ldap, python-memcache, memcached, python-sqlite
 
-  if ($::osfamily == 'RedHat' and $::operatingsystemrelease =~ /^7\.\d+/) or ($::graphite::params::service_provider == 'systemd') {
+  if ($::osfamily == 'RedHat' and $::operatingsystemrelease =~ /^7\.\d+/) or ($::graphite::gr_service_provider == 'systemd') {
     $initscript_notify = [Exec['graphite-reload-systemd'],]
 
     exec { 'graphite-reload-systemd':
@@ -303,7 +303,7 @@ class graphite::config inherits graphite::params {
       enable     => true,
       hasrestart => true,
       hasstatus  => true,
-      provider   => $::graphite::params::service_provider,
+      provider   => $::graphite::gr_service_provider,
       require    => File['/etc/init.d/carbon-cache'],
     }
 
@@ -322,7 +322,7 @@ class graphite::config inherits graphite::params {
       enable     => true,
       hasrestart => true,
       hasstatus  => true,
-      provider   => $::graphite::params::service_provider,
+      provider   => $::graphite::gr_service_provider,
       require    => File['/etc/init.d/carbon-relay'],
     }
 
@@ -341,7 +341,7 @@ class graphite::config inherits graphite::params {
       enable     => true,
       hasrestart => true,
       hasstatus  => true,
-      provider   => $::graphite::params::service_provider,
+      provider   => $::graphite::gr_service_provider,
       require    => File['/etc/init.d/carbon-aggregator'],
     }
 

--- a/manifests/config_gunicorn.pp
+++ b/manifests/config_gunicorn.pp
@@ -37,7 +37,7 @@ class graphite::config_gunicorn inherits graphite::params {
 
       # RedHat package is missing initscript
       # RedHat 7+ uses systemd
-      if $::graphite::params::service_provider == 'systemd' {
+      if $::graphite::gr_service_provider == 'systemd' {
 
         file { '/etc/systemd/system/gunicorn.service':
           ensure  => file,
@@ -133,7 +133,7 @@ class graphite::config_gunicorn inherits graphite::params {
     enable     => true,
     hasrestart => true,
     hasstatus  => false,
-    provider   => $::graphite::params::service_provider,
+    provider   => $::graphite::gr_service_provider,
     require    => [
       Package[$package_name],
       File["${::graphite::graphiteweb_conf_dir_REAL}/graphite_wsgi.py"]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,10 @@
 #   The user who runs graphite. If this is empty carbon runs as the user that
 #   invokes it.
 #   Default is empty.
+# [*gr_service_provider*]
+#   Service provider used to start, stop, restart etc. services managed by this
+#   module.
+#   Default is debian / redhat / systemd (autodected. see params.pp)
 # [*gr_enable_carbon_cache*]
 #   Enable carbon cache.
 #   Default is true.
@@ -527,6 +531,7 @@
 class graphite (
   $gr_group                               = '',
   $gr_user                                = '',
+  $gr_service_provider                    = $::graphite::params::service_provider,
   $gr_enable_carbon_cache                 = true,
   $gr_max_cache_size                      = inf,
   $gr_max_updates_per_second              = 500,


### PR DESCRIPTION
This module decides for the service provider by checking the OS and version. This is normally ok, but specially on Debian systems since the change to systemd, many administrators stayed with the old style.

Therefore this patch enables this module to to allow the user setting the service provider manually if he/she chooses to.

Related to issue "Manually setting service_provider parameter #310"
