### PR TITLE
Add the ability to specify an alternative python binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,6 +946,10 @@ Default is `undef` (string) The provider of the django package that should be in
 
 Default is true (Bool). Should packages be installed via pip
 
+#####`gr_python_binary`
+
+Default is 'python' (string). Can be set to a fully-qualify path or an alternative binary name.
+
 #####`gr_disable_webapp_cache`
 
 Default is false (Bool). Should the caching of the webapp be disabled. This helps with some

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -98,7 +98,7 @@ class graphite::config inherits graphite::params {
 
   # first init of user db for graphite
   exec { 'Initial django db creation':
-    command     => 'python manage.py syncdb --noinput',
+    command     => "$::graphite::gr_python_binary manage.py syncdb --noinput",
     cwd         => $graphite_web_managepy_location,
     refreshonly => true,
     require     => $syncdb_require,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -98,7 +98,7 @@ class graphite::config inherits graphite::params {
 
   # first init of user db for graphite
   exec { 'Initial django db creation':
-    command     => "$::graphite::gr_python_binary manage.py syncdb --noinput",
+    command     => "${::graphite::gr_python_binary} manage.py syncdb --noinput",
     cwd         => $graphite_web_managepy_location,
     refreshonly => true,
     require     => $syncdb_require,

--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -79,7 +79,7 @@ class graphite::config_apache inherits graphite::params {
     mode   => '0755',
   }
   exec { 'fix graphite race condition':
-    command     => "$::graphite::gr_python_binary /tmp/fix-graphite-race-condition.py",
+    command     => "${::graphite::gr_python_binary} /tmp/fix-graphite-race-condition.py",
     cwd         => $graphite::graphiteweb_webapp_dir_REAL,
     environment => 'DJANGO_SETTINGS_MODULE=graphite.settings',
     user        => $graphite::config::gr_web_user_REAL,

--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -79,7 +79,7 @@ class graphite::config_apache inherits graphite::params {
     mode   => '0755',
   }
   exec { 'fix graphite race condition':
-    command     => 'python /tmp/fix-graphite-race-condition.py',
+    command     => "$::graphite::gr_python_binary /tmp/fix-graphite-race-condition.py",
     cwd         => $graphite::graphiteweb_webapp_dir_REAL,
     environment => 'DJANGO_SETTINGS_MODULE=graphite.settings',
     user        => $graphite::config::gr_web_user_REAL,

--- a/manifests/config_gunicorn.pp
+++ b/manifests/config_gunicorn.pp
@@ -98,7 +98,7 @@ class graphite::config_gunicorn inherits graphite::params {
       mode   => '0755',
     }
     exec { 'fix graphite race condition':
-      command     => 'python /tmp/fix-graphite-race-condition.py',
+      command     => "$::graphite::gr_python_binary /tmp/fix-graphite-race-condition.py",
       cwd         => $graphite::graphiteweb_webapp_dir_REAL,
       environment => 'DJANGO_SETTINGS_MODULE=graphite.settings',
       user        => $graphite::config::gr_web_user_REAL,

--- a/manifests/config_gunicorn.pp
+++ b/manifests/config_gunicorn.pp
@@ -98,7 +98,7 @@ class graphite::config_gunicorn inherits graphite::params {
       mode   => '0755',
     }
     exec { 'fix graphite race condition':
-      command     => "$::graphite::gr_python_binary /tmp/fix-graphite-race-condition.py",
+      command     => "${::graphite::gr_python_binary} /tmp/fix-graphite-race-condition.py",
       cwd         => $graphite::graphiteweb_webapp_dir_REAL,
       environment => 'DJANGO_SETTINGS_MODULE=graphite.settings',
       user        => $graphite::config::gr_web_user_REAL,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -749,6 +749,7 @@ class graphite (
   $gr_django_provider                     = $::graphite::params::django_provider,
   $gr_pip_install                         = true,
   $gr_manage_python_packages              = true,
+  $gr_python_binary                       = $::graphite::params::python_binary,
   $gr_disable_webapp_cache                = false,
   $gr_carbonlink_query_bulk               = undef,
   $gr_carbonlink_hosts_timeout            = '1.0',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,9 @@ class graphite::params {
   $django_ver            = '1.5'
   $django_source         = undef
   $django_provider       = 'pip'
+  $python_binary         = 'python'
+
+  $install_prefix     = '/opt/'
 
   # variables to workaround unusual graphite install target:
   # https://github.com/graphite-project/carbon/issues/86

--- a/templates/etc/init.d/Debian/carbon-aggregator.erb
+++ b/templates/etc/init.d/Debian/carbon-aggregator.erb
@@ -12,7 +12,7 @@
 # Description: Enables Graphites carbon-aggregator data aggregation engine
 ### END INIT INFO
 
-PYTHON_CMD='python -W ignore'
+PYTHON_CMD='<%= scope.lookupvar('graphite::gr_python_binary') %> -W ignore'
 CARBON_DAEMON="aggregator"
 GRAPHITE_DIR="<%= scope.lookupvar('graphite::base_dir_REAL') %>"
 STOP_COUNTER=12 # 12 times 5s -> 60 secs

--- a/templates/etc/init.d/Debian/carbon-cache.erb
+++ b/templates/etc/init.d/Debian/carbon-cache.erb
@@ -12,7 +12,7 @@
 # Description: Enables Graphites carbon-cache data cache engine
 ### END INIT INFO
 
-PYTHON_CMD='python -W ignore'
+PYTHON_CMD='<%= scope.lookupvar('graphite::gr_python_binary') %> -W ignore'
 CARBON_DAEMON="cache"
 GRAPHITE_DIR="<%= scope.lookupvar('graphite::base_dir_REAL') %>"
 STOP_COUNTER=12 # 12 times 5s -> 60 secs

--- a/templates/etc/init.d/Debian/carbon-relay.erb
+++ b/templates/etc/init.d/Debian/carbon-relay.erb
@@ -12,7 +12,7 @@
 # Description: Enables Graphites carbon-relay
 ### END INIT INFO
 
-PYTHON_CMD='python -W ignore'
+PYTHON_CMD='<%= scope.lookupvar('graphite::gr_python_binary') %> -W ignore'
 CARBON_DAEMON="relay"
 GRAPHITE_DIR="<%= scope.lookupvar('graphite::base_dir_REAL') %>"
 STOP_COUNTER=12 # 12 times 5s -> 60 secs

--- a/templates/etc/init.d/RedHat/carbon-aggregator.erb
+++ b/templates/etc/init.d/RedHat/carbon-aggregator.erb
@@ -19,7 +19,7 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-PYTHON_CMD='python -W ignore'
+PYTHON_CMD='<%= scope.lookupvar('graphite::gr_python_binary') %> -W ignore'
 CARBON_DAEMON="aggregator"
 GRAPHITE_DIR="<%= scope.lookupvar('graphite::base_dir_REAL') %>"
 PIDFILE_DIR="<%= scope.lookupvar('graphite::storage_dir_REAL') %>"

--- a/templates/etc/init.d/RedHat/carbon-cache.erb
+++ b/templates/etc/init.d/RedHat/carbon-cache.erb
@@ -19,7 +19,7 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-PYTHON_CMD='python -W ignore'
+PYTHON_CMD='<%= scope.lookupvar('graphite::gr_python_binary') %> -W ignore'
 CARBON_DAEMON="cache"
 GRAPHITE_DIR="<%= scope.lookupvar('graphite::base_dir_REAL') %>"
 PIDFILE_DIR="<%= scope.lookupvar('graphite::storage_dir_REAL') %>"

--- a/templates/etc/init.d/RedHat/carbon-relay.erb
+++ b/templates/etc/init.d/RedHat/carbon-relay.erb
@@ -19,7 +19,7 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-PYTHON_CMD='python -W ignore'
+PYTHON_CMD='<%= scope.lookupvar('graphite::gr_python_binary') %> -W ignore'
 CARBON_DAEMON="relay"
 GRAPHITE_DIR="<%= scope.lookupvar('graphite::base_dir_REAL') %>"
 PIDFILE_DIR="<%= scope.lookupvar('graphite::storage_dir_REAL') %>"


### PR DESCRIPTION
This is needed on machines where you have multiple versions of python
installed, including RHEL 6.x with python27, and more. Everywhere python
is called directly has been replaced with the value of
'gr_python_binary', which defaults to just 'python' (i.e., what it was
before).

This *should* finally be right. Sorry again.