### PR TITLE
Add option to disable carbon built-in log rotation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -678,6 +678,7 @@ class graphite (
   $gr_whitelists_dir                      = undef,
   $gr_carbon_conf_dir                     = undef,
   $gr_carbon_log_dir                      = undef,
+  $gr_carbon_log_rotate                   = 'True',
   $gr_graphiteweb_log_dir                 = undef,
   $gr_graphiteweb_conf_dir                = undef,
   $gr_graphiteweb_webapp_dir              = undef,

--- a/templates/opt/graphite/conf/carbon.conf.erb
+++ b/templates/opt/graphite/conf/carbon.conf.erb
@@ -332,7 +332,7 @@ CARBON_METRIC_INTERVAL = <%= scope.lookupvar('graphite::gr_carbon_metric_interva
 
 [aggregator]
 # Enable daily log rotation. If disabled, a kill -HUP can be used after a manual rotate
-ENABLE_LOGROTATION = True
+ENABLE_LOGROTATION = <%= scope.lookupvar('graphite::gr_carbon_log_rotate') %>
 
 # Specify the user to drop privileges to
 # If this is blank carbon runs as the user that invokes it


### PR DESCRIPTION
This change allows the ENABLE_LOGROTATION option to be overridden in carbon.conf.