### PR TITLE
Fix permissions error when executing fix-graphite-race-condition.py

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -158,11 +158,12 @@ class graphite::config inherits graphite::params {
 
   # Lets ensure graphite.db owner is the same as gr_web_user_REAL
   file { "${::graphite::storage_dir_REAL}/graphite.db":
-    ensure  => file,
-    group   => $gr_web_group_REAL,
-    mode    => '0644',
-    seltype => 'httpd_sys_rw_content_t',
-    owner   => $gr_web_user_REAL;
+    ensure    => file,
+    group     => $gr_web_group_REAL,
+    mode      => '0644',
+    seltype   => 'httpd_sys_rw_content_t',
+    owner     => $gr_web_user_REAL,
+    subscribe => Exec['Initial django db creation'],
   }
 
   # Deploy configfiles

--- a/manifests/config_apache.pp
+++ b/manifests/config_apache.pp
@@ -92,6 +92,7 @@ class graphite::config_apache inherits graphite::params {
       File[$::graphite::storage_dir_REAL],
       File[$::graphite::graphiteweb_log_dir_REAL],
       File[$::graphite::graphiteweb_storage_dir_REAL],
+      File["${::graphite::storage_dir_REAL}/graphite.db"],
     ],
     before      => Service[$::graphite::params::apache_service_name],
     subscribe   => Exec['Initial django db creation'],


### PR DESCRIPTION
Puppet was getting permissions errors while executing `fix-graphite-race-condition.py`, due to the database being owned by root rather than www-data. This fixes that.