### PR TITLE
Fix line endings in templates directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto
+
+# Templates need to always use *nix-style line endings, as they can sometimes
+# be copied from a Windows machine to a *nix machine and used there (such as
+# when running Beaker tests on a Windows host).
+templates/** eol=lf


### PR DESCRIPTION
Currently, git will sometimes convert the line-endings of text files in the repo to Windows-style (CRLF) on checkout when running on Windows.

Templates need to always use *nix-style line endings, as they can sometimes be copied from a Windows machine to a *nix machine and used there (such as when running Beaker tests on a Windows host).