### PR TITLE
Symlink correct target when installing carbon or gweb from a URL or file source

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -36,9 +36,6 @@ class graphite::install inherits graphite::params {
     $gr_pkg_require = [Package[$::graphite::params::graphitepkgs]]
   }
 
-  $carbon = "carbon-${::graphite::gr_carbon_ver}-py${::graphite::params::pyver}.egg-info"
-  $gweb = "graphite_web-${::graphite::gr_graphite_ver}-py${::graphite::params::pyver}.egg-info"
-
   # # Manage resources
 
   # for full functionality we need these packages:
@@ -110,21 +107,22 @@ class graphite::install inherits graphite::params {
     }
 
     # hack unusual graphite install target
-    create_resources('file', {
+    $carbon = "\"carbon-\"*\"-py${::graphite::params::pyver}.egg-info\""
+    $gweb = "\"graphite_web-\"*\"-py${::graphite::params::pyver}.egg-info\""
+    create_resources('exec', {
       'carbon_hack' => {
-        path   => "${::graphite::params::libpath}/${carbon}",
-        target => "${::graphite::base_dir_REAL}/lib/${carbon}"
+        command => "ln -s \"${::graphite::base_dir_REAL}/lib/\"${carbon} \"${::graphite::params::libpath}/\""
       }
       ,
       'gweb_hack'   => {
-        path   => "${::graphite::params::libpath}/${gweb}",
-        target => "${::graphite::base_dir_REAL}/webapp/${gweb}"
+        command => "ln -s \"${::graphite::base_dir_REAL}/webapp/\"${gweb} \"${::graphite::params::libpath}/\""
       }
       ,
     }
     , {
-      ensure  => 'link',
-      require => Package['carbon', 'graphite-web', 'whisper'],
+      refreshonly => true,
+      subscribe   => Package['carbon', 'graphite-web', 'whisper'],
+      provider    => 'shell',
     }
     )
   }

--- a/spec/classes/graphite_install_spec.rb
+++ b/spec/classes/graphite_install_spec.rb
@@ -4,8 +4,9 @@ describe 'graphite::install', :type => 'class' do
 
   # Convenience variable for 'hack' file checks
   hack_defaults = {
-    :ensure  => 'link',
-    :require => ['Package[carbon]','Package[graphite-web]','Package[whisper]'],
+    :refreshonly => true,
+    :provider    => 'shell',
+    :subscribe   => ['Package[carbon]','Package[graphite-web]','Package[whisper]'],
   }
 
   shared_context 'supported platforms' do
@@ -20,8 +21,8 @@ describe 'graphite::install', :type => 'class' do
         'Package[python-ldap]').that_requires(
         'Package[python-psycopg2]') }
     end
-    it { is_expected.to contain_file('carbon_hack').with(hack_defaults) }
-    it { is_expected.to contain_file('gweb_hack').with(hack_defaults) }
+    it { is_expected.to contain_exec('carbon_hack').with(hack_defaults) }
+    it { is_expected.to contain_exec('gweb_hack').with(hack_defaults) }
   end
 
   shared_context 'no pip' do
@@ -33,8 +34,8 @@ describe 'graphite::install', :type => 'class' do
     it { is_expected.not_to contain_package('python-pip') }
     it { is_expected.not_to contain_package('python-dev') }
     it { is_expected.not_to contain_package('python-devel') }
-    it { is_expected.not_to contain_file('carbon_hack') }
-    it { is_expected.not_to contain_file('gweb_hack')   }
+    it { is_expected.not_to contain_exec('carbon_hack') }
+    it { is_expected.not_to contain_exec('gweb_hack')   }
   end
 
   shared_context 'no django' do
@@ -64,13 +65,11 @@ describe 'graphite::install', :type => 'class' do
     it { is_expected.to contain_package('bitmap-fonts-compat').with_provider(nil) }
     it { is_expected.to contain_package('python-crypto').with_provider(nil) }
 
-    it { is_expected.to contain_file('carbon_hack').only_with(hack_defaults.merge({
-      :target => '/opt/graphite/lib/carbon-0.9.15-py2.6.egg-info',
-      :path   => '/usr/lib/python2.6/site-packages/carbon-0.9.15-py2.6.egg-info',
+    it { is_expected.to contain_exec('carbon_hack').only_with(hack_defaults.merge({
+      :command => 'ln -s "/opt/graphite/lib/""carbon-"*"-py2.6.egg-info" "/usr/lib/python2.6/site-packages/"',
     })) }
-    it { should contain_file('gweb_hack').only_with(hack_defaults.merge({
-      :target => '/opt/graphite/webapp/graphite_web-0.9.15-py2.6.egg-info',
-      :path   => '/usr/lib/python2.6/site-packages/graphite_web-0.9.15-py2.6.egg-info',
+    it { should contain_exec('gweb_hack').only_with(hack_defaults.merge({
+      :command => 'ln -s "/opt/graphite/webapp/""graphite_web-"*"-py2.6.egg-info" "/usr/lib/python2.6/site-packages/"',
     })) }
   end
 
@@ -82,13 +81,11 @@ describe 'graphite::install', :type => 'class' do
     it { is_expected.to contain_package('dejavu-sans-fonts').with_provider(nil) }
     it { is_expected.to contain_package('python2-crypto').with_provider(nil) }
 
-    it { is_expected.to contain_file('carbon_hack').only_with(hack_defaults.merge({
-      :target => '/opt/graphite/lib/carbon-0.9.15-py2.7.egg-info',
-      :path   => '/usr/lib/python2.7/site-packages/carbon-0.9.15-py2.7.egg-info',
+    it { is_expected.to contain_exec('carbon_hack').only_with(hack_defaults.merge({
+      :command => 'ln -s "/opt/graphite/lib/""carbon-"*"-py2.7.egg-info" "/usr/lib/python2.7/site-packages/"',
     })) }
-    it { is_expected.to contain_file('gweb_hack').only_with(hack_defaults.merge({
-      :target => '/opt/graphite/webapp/graphite_web-0.9.15-py2.7.egg-info',
-      :path   => '/usr/lib/python2.7/site-packages/graphite_web-0.9.15-py2.7.egg-info',
+    it { is_expected.to contain_exec('gweb_hack').only_with(hack_defaults.merge({
+      :command => 'ln -s "/opt/graphite/webapp/""graphite_web-"*"-py2.7.egg-info" "/usr/lib/python2.7/site-packages/"',
     })) }
   end
 
@@ -112,8 +109,8 @@ describe 'graphite::install', :type => 'class' do
       let(:facts) do
         facts
       end
-      let :pre_condition do 
-        'include ::graphite' 
+      let :pre_condition do
+        'include ::graphite'
       end
 
       case facts[:osfamily]


### PR DESCRIPTION
Previously, setting `gr_carbon_source` or `gr_graphite_source` to a URL or local file representing the appropriate pip package, while also setting the coresponding package version to `'present'` would result in Puppet attempting to use names like `graphite_web-present-py2.7.egg-info` when creating symlinks to the packages. This fixes that so that the correct file names are used.