### PR TITLE
Add `gr_pip_install_options` param for setting install_options for pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,18 @@ You can also chose to install the pip packages from a source other than PyPI, su
   }
 ```
 
+You can also specify an alternate source for all packages (and their dependencies) by passing options to `pip install` using `gr_pip_install_options`:
+```puppet
+  class { '::graphite':
+    gr_pip_install_options => [
+      '--no-index',
+      '--find-links', 'https://example.com/pip_packages/',
+    ],
+  }
+```
+
+For more details on how these options work, see the [documentation for `pip install`](https://pip.pypa.io/en/stable/reference/pip_install/).
+
 ## Usage
 
 #### Class: `graphite`
@@ -948,6 +960,16 @@ Default is `undef` (string) The provider of the django package that should be in
 ##### `gr_pip_install_options`
 
 Default is `undef` (array). An array of options to pass to `pip install` when installing graphite.
+
+For example, to install packages from a repository other than PyPI, you could pass `--index-url` like this:
+
+```puppet
+  class { 'graphite':
+    gr_pip_install_options => ['--index-url', 'https://custom-packge-server/simple/'],
+  }
+```
+
+For details on available options, see the [documentation for `pip install`](https://pip.pypa.io/en/stable/reference/pip_install/).
 
 ##### `gr_pip_install`
 

--- a/README.md
+++ b/README.md
@@ -945,6 +945,10 @@ Default is `undef` (string). The source of the django package that should be ins
 
 Default is `undef` (string) The provider of the django package that should be installed.
 
+##### `gr_pip_install_options`
+
+Default is `undef` (array). An array of options to pass to `pip install` when installing graphite.
+
 ##### `gr_pip_install`
 
 Default is true (Bool). Should packages be installed via pip

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -503,6 +503,9 @@
 # [*gr_django_provider*]
 #   String. The provider to use for installing django.
 #   Default: pip
+# [*gr_pip_install_options*]
+#   Array. Options to pass to `pip install` when installing graphite.
+#   Default: undef
 # [*gr_pip_install*]
 #   Boolean. Should the package be installed via pip
 #   Default: true
@@ -750,6 +753,7 @@ class graphite (
   $gr_django_ver                          = $::graphite::params::django_ver,
   $gr_django_source                       = $::graphite::params::django_source,
   $gr_django_provider                     = $::graphite::params::django_provider,
+  $gr_pip_install_options                 = $::graphite::params::pip_install_options,
   $gr_pip_install                         = true,
   $gr_manage_python_packages              = true,
   $gr_python_binary                       = $::graphite::params::python_binary,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,6 +17,14 @@ class graphite::install inherits graphite::params {
     )
   }
 
+  $pip_install_options = $::graphite::params::extra_pip_install_options ? {
+    undef   => $::graphite::gr_pip_install_options,
+    default => union(
+      $::graphite::params::extra_pip_install_options,
+      pick($::graphite::gr_pip_install_options, [])
+    )
+  }
+
   # # Set class variables
   $gr_pkg_provider = $::graphite::gr_pip_install ? {
     true    => 'pip',
@@ -91,7 +99,7 @@ class graphite::install inherits graphite::params {
     provider        => $gr_pkg_provider,
     require         => $gr_pkg_require,
     install_options => $gr_pkg_provider ? {
-      'pip'   => $::graphite::params::pip_install_options,
+      'pip'   => $pip_install_options,
       default => undef,
     },
   }
@@ -99,7 +107,7 @@ class graphite::install inherits graphite::params {
 
   if $::graphite::gr_django_pkg {
     $django_install_options = $::graphite::gr_django_provider ? {
-      'pip'   => $::graphite::params::pip_install_options,
+      'pip'   => $pip_install_options,
       default => undef,
     }
     package { $::graphite::gr_django_pkg:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,7 @@ class graphite::params {
   $django_ver            = '1.5'
   $django_source         = undef
   $django_provider       = 'pip'
+  $pip_install_options   = undef
   $python_binary         = 'python'
 
   $install_prefix     = '/opt/'
@@ -92,24 +93,24 @@ class graphite::params {
 
       case $::lsbdistcodename {
         /squeeze|wheezy|precise/: {
-          $apache_24           = false
-          $graphitepkgs        = union($common_os_pkgs, ['python-cairo',])
-          $libpath             = "/usr/lib/python${pyver}/dist-packages"
-          $pip_install_options = undef
+          $apache_24                 = false
+          $graphitepkgs              = union($common_os_pkgs, ['python-cairo',])
+          $libpath                   = "/usr/lib/python${pyver}/dist-packages"
+          $extra_pip_install_options = undef
         }
 
         /jessie|trusty|utopic|vivid|wily/: {
-          $apache_24           = true
-          $graphitepkgs        = union($common_os_pkgs, ['python-cairo',])
-          $libpath             = "/usr/lib/python${pyver}/dist-packages"
-          $pip_install_options = undef
+          $apache_24                 = true
+          $graphitepkgs              = union($common_os_pkgs, ['python-cairo',])
+          $libpath                   = "/usr/lib/python${pyver}/dist-packages"
+          $extra_pip_install_options = undef
         }
 
         /xenial/: {
-          $apache_24           = true
-          $graphitepkgs        = union($common_os_pkgs, ['python-cairo',])
-          $libpath             = "/usr/local/lib/python${pyver}/dist-packages"
-          $pip_install_options = [{'--no-binary' => ':all:'}]
+          $apache_24                 = true
+          $graphitepkgs              = union($common_os_pkgs, ['python-cairo',])
+          $libpath                   = "/usr/local/lib/python${pyver}/dist-packages"
+          $extra_pip_install_options = [{'--no-binary' => ':all:'}]
         }
 
         default: {
@@ -188,7 +189,7 @@ class graphite::params {
 
       $libpath = "/usr/lib/python${pyver}/site-packages"
 
-      $pip_install_options = undef
+      $extra_pip_install_options = undef
     }
 
     default: {


### PR DESCRIPTION
Darn, looks like I just barely missed the 7.0 release with this one. Oh well.

This allows passing custom options to pip install, in addition to the ones automatically added when installing on Ubuntu Xenial.

Currently using this with the `--no-index` and `--find-links` options in one of my projects to allow automatically pulling dependencies from an HTTP source without having to pass them explicitly. This is basically necessary for offline installs, since otherwise pip can't find Twisted's dependencies (since it can't get out to PyPI).