### PR TITLE
Fix for #329 in echocat/puppet-graphite

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -809,10 +809,10 @@ class graphite (
   # implementation classes through a transitive relationship to
   # the composite class.
   # https://projects.puppetlabs.com/projects/puppet/wiki/Anchor_Pattern
-  Anchor['graphite::begin'] ->
-  Class['graphite::install'] ~>
-  Class['graphite::config'] ->
-  Anchor['graphite::end']
+  Anchor['graphite::begin']
+  -> Class['graphite::install']
+  ~> Class['graphite::config']
+  -> Anchor['graphite::end']
 
   anchor { 'graphite::begin': }
   include graphite::install

--- a/templates/opt/graphite/conf/carbon.conf.erb
+++ b/templates/opt/graphite/conf/carbon.conf.erb
@@ -32,6 +32,10 @@
 #
 LOCAL_DATA_DIR = <%= scope.lookupvar('graphite::local_data_dir_REAL') %>/
 
+<% unless [:undef, nil].include? scope.lookupvar('graphite::gr_storage_dir') -%>
+PID_DIR = <%= scope.lookupvar('graphite::gr_storage_dir') %>
+<% end -%>
+
 # Enable daily log rotation. If disabled, a kill -HUP can be used after a manual rotate
 ENABLE_LOGROTATION = True
 


### PR DESCRIPTION
PR to incorporate previously published patch which generates proper config for carbon-cache instances.
See #329 for more details.