### PR TITLE
Updated python-pip to python2-pip for RedHat 7 variants

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -148,12 +148,12 @@ class graphite::params {
         $apache_wsgi_pkg = 'mod_wsgi'
         $pytz            = 'python-tzlocal'
         $python_pip_pkg  = $::osfamily ? {
-           'RedHat'  => $::operatingsystemrelease ? {
-             /^7/    => 'python2-pip',
-             default => 'python-pip'
-           },
-           default   => 'python-pip',
-         }
+          'RedHat'  => $::operatingsystemrelease ? {
+            /^7/    => 'python2-pip',
+            default => 'python-pip'
+          },
+          default   => 'python-pip',
+        }
       }
 
       $python_dev_pkg = ["${python}-devel", 'gcc']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -147,7 +147,13 @@ class graphite::params {
         $pyopenssl       = 'pyOpenSSL'
         $apache_wsgi_pkg = 'mod_wsgi'
         $pytz            = 'python-tzlocal'
-        $python_pip_pkg  = 'python-pip'
+        $python_pip_pkg  = $::osfamily ? {
+           'RedHat'  => $::operatingsystemrelease ? {
+             /^7/    => 'python2-pip',
+             default => 'python-pip'
+           },
+           default   => 'python-pip',
+         }
       }
 
       $python_dev_pkg = ["${python}-devel", 'gcc']

--- a/spec/classes/graphite_install_spec.rb
+++ b/spec/classes/graphite_install_spec.rb
@@ -74,6 +74,7 @@ describe 'graphite::install', :type => 'class' do
   end
 
   shared_context 'RedHat 7 platforms' do
+    it { is_expected.to contain_package('python2-pip').with_provider(nil) }
     it { is_expected.to contain_package('python-cairocffi').with_provider(nil) }
     it { is_expected.to contain_package('Django').with_provider('pip') }
     it { is_expected.to contain_package('python-sqlite3dbm').with_provider(nil) }
@@ -128,11 +129,12 @@ describe 'graphite::install', :type => 'class' do
           it_behaves_like 'no django'
         end
       when 'RedHat' then
-        it_behaves_like 'supported platforms'
+        #it_behaves_like 'supported platforms'
         it_behaves_like 'RedHat supported platforms'
 
         case facts[:operatingsystemrelease]
         when /^6/ then
+          it_behaves_like 'supported platforms'
           it_behaves_like 'RedHat 6 platforms'
         when /^7/ then
           it_behaves_like 'RedHat 7 platforms'


### PR DESCRIPTION
CentOS 7.3 appears to be looking for python2-pip instead of just python-pip. I've updated the params.pp to support that. 

Please let me know the correct way to fix the spec tests for ensuring that RedHat 7 should use python2-pip while others should use python-pip. I'm sure the way I changed graphite_install_spec.rb is incorrect and there could be a better way.

Thanks!