### PR TITLE
Add a new parameter : gr_base_dir_managed_externally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Gemfile.lock
 
 # idea
 ./idea
+.idea/
 
 # geppetto/eclipse
 .project

--- a/README.md
+++ b/README.md
@@ -385,6 +385,10 @@ Default is 'GMT' (string). Timezone for graphite to be used.
 
 Default is '/opt/graphite'. Set base install location of Graphite. This forms the base location for installs, predominantly appropriate for pip installations. When not installing using pip a typical location for this may be '/opt/carbon'.
 
+#### `gr_base_dir_managed_externally`
+
+Default is 'False'. Useful if the base install location of Graphite is managed by other Puppet resource (like a mountpoint for example)
+
 ##### `gr_storage_dir`
 
 Default is '${gr_base_dir}/storage'. Set location of base storage files.  When not installing using pip a typical location for this may be '/opt/carbon'. This dir is also used as pid dir on RedHat.

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Default is '/opt/graphite'. Set base install location of Graphite. This forms th
 
 #### `gr_base_dir_managed_externally`
 
-Default is 'False'. Useful if the base install location of Graphite is managed by other Puppet resource (like a mountpoint for example)
+Boolean, default to false . Useful if the base install location of Graphite is managed by other Puppet resource (like a mountpoint for example)
 
 ##### `gr_storage_dir`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -105,13 +105,15 @@ class graphite::config inherits graphite::params {
     subscribe   => Class['graphite::install'],
   }
 
-  # change access permissions for web server
-  file { $::graphite::base_dir_REAL:
-    ensure  => directory,
-    group   => $gr_web_group_REAL,
-    mode    => '0755',
-    owner   => $gr_web_user_REAL,
-    seltype => 'httpd_sys_rw_content_t',
+  if !$::graphite::gr_base_dir_managed_externally {
+    # change access permissions for web server
+    file { $::graphite::base_dir_REAL:
+      ensure  => directory,
+      group   => $gr_web_group_REAL,
+      mode    => '0755',
+      owner   => $gr_web_user_REAL,
+      seltype => 'httpd_sys_rw_content_t',
+    }
   }
 
   file { [

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -702,7 +702,7 @@ class graphite (
   ,
   $gr_use_remote_user_auth                = 'False',
   $gr_remote_user_header_name             = undef,
-  $gr_base_dir_managed_externally         = 'False',
+  $gr_base_dir_managed_externally         = undef,
   $gr_base_dir                            = '/opt/graphite',
   $gr_storage_dir                         = undef,
   $gr_local_data_dir                      = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -702,7 +702,7 @@ class graphite (
   ,
   $gr_use_remote_user_auth                = 'False',
   $gr_remote_user_header_name             = undef,
-  $gr_base_dir_managed_externally         = undef,
+  $gr_base_dir_managed_externally         = false,
   $gr_base_dir                            = '/opt/graphite',
   $gr_storage_dir                         = undef,
   $gr_local_data_dir                      = undef,
@@ -783,6 +783,7 @@ class graphite (
   validate_bool($gr_pip_install)
   validate_bool($gr_manage_python_packages)
   validate_bool($gr_disable_webapp_cache)
+  validate_bool($gr_base_dir_managed_externally)
 
   if $gr_apache_port or $gr_apache_port_https {
     fail('$gr_apache_port and $gr_apache_port_https are deprecated in favour of $gr_web_server_port and $gr_web_server_port_https')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -702,6 +702,7 @@ class graphite (
   ,
   $gr_use_remote_user_auth                = 'False',
   $gr_remote_user_header_name             = undef,
+  $gr_base_dir_managed_externally         = 'False',
   $gr_base_dir                            = '/opt/graphite',
   $gr_storage_dir                         = undef,
   $gr_local_data_dir                      = undef,


### PR DESCRIPTION
Hi

following #338 , I would like to submit this PR.

It adds a new parameter : `gr_base_dir_managed_externally`

This parameter is useful for us, as we already manage `base_dir` in another puppet module (for managing a mountpoint).

Thanks a lot !

Thomas