### PR TITLE
parameterize initial django db creation

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -98,7 +98,8 @@ class graphite::config inherits graphite::params {
 
   # first init of user db for graphite
   exec { 'Initial django db creation':
-    command     => "${::graphite::gr_python_binary} manage.py syncdb --noinput",
+    command     => $::graphite::gr_django_init_command,
+    provider    => $::graphite::gr_django_init_provider,
     cwd         => $graphite_web_managepy_location,
     refreshonly => true,
     require     => $syncdb_require,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -732,6 +732,8 @@ class graphite (
   $wsgi_processes                         = 5,
   $wsgi_threads                           = 5,
   $wsgi_inactivity_timeout                = 120,
+  $gr_django_init_provider                = $::graphite::params::gr_django_init_provider,
+  $gr_django_init_command                 = $::graphite::params::gr_django_init_command,
   $gr_django_tagging_pkg                  = $::graphite::params::django_tagging_pkg,
   $gr_django_tagging_ver                  = $::graphite::params::django_tagging_ver,
   $gr_django_tagging_source               = $::graphite::params::django_tagging_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,6 +37,10 @@ class graphite::params {
 
   $install_prefix     = '/opt/'
 
+  # variables for django db initialization
+  $gr_django_init_provider = 'posix'
+  $gr_django_init_command  = "${::graphite::gr_python_binary} manage.py syncdb --noinput"
+
   # variables to workaround unusual graphite install target:
   # https://github.com/graphite-project/carbon/issues/86
   $pyver              = $::osfamily ? {


### PR DESCRIPTION
Hi,
I recently upgraded our graphite installations to newest stable version (1.0.2), for this I needed to upgrade Django to a higher version, where "manage.py" doesn't exist anymore, which caused issues with the way you handle initial creation of the Django DB.

With this patch, that simply adds a few parameters in the 'Initial django db creation' exec I was able to make it work. I am not sure about the naming scheme, so please take a look at it and let me know if I should change anything.

Thank you!