### PR TITLE
parameterize initial django db creation

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -98,7 +98,8 @@ class graphite::config inherits graphite::params {
 
   # first init of user db for graphite
   exec { 'Initial django db creation':
-    command     => "${::graphite::gr_python_binary} manage.py syncdb --noinput",
+    command     => $::graphite::gr_django_init_command,
+    provider    => $::graphite::gr_django_init_provider,
     cwd         => $graphite_web_managepy_location,
     refreshonly => true,
     require     => $syncdb_require,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -437,6 +437,12 @@
 # [*wsgi_inactivity-timeout*]
 #   WSGI inactivity-timeout in seconds.
 #   Default is 120
+# [*gr_django_init_provider*]
+#   Provider for the Django DB initialization exec.
+#   Default: 'posix'
+# [*gr_django_init_command]
+#   Command to use for the Django DB initialization exec.
+#   default: "${::graphite::gr_python_binary} manage.py syncdb --noinput"
 # [*gr_django_tagging_pkg*]
 #   String. The name of the django tagging package to install
 #   Default: django-tagging
@@ -732,8 +738,8 @@ class graphite (
   $wsgi_processes                         = 5,
   $wsgi_threads                           = 5,
   $wsgi_inactivity_timeout                = 120,
-  $gr_django_init_provider                = $::graphite::params::gr_django_init_provider,
-  $gr_django_init_command                 = $::graphite::params::gr_django_init_command,
+  $gr_django_init_provider                = "${::graphite::params::gr_python_binary} manage.py syncdb --noinput",
+  $gr_django_init_command                 = $::graphite::params::django_init_command,
   $gr_django_tagging_pkg                  = $::graphite::params::django_tagging_pkg,
   $gr_django_tagging_ver                  = $::graphite::params::django_tagging_ver,
   $gr_django_tagging_source               = $::graphite::params::django_tagging_source,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -732,6 +732,8 @@ class graphite (
   $wsgi_processes                         = 5,
   $wsgi_threads                           = 5,
   $wsgi_inactivity_timeout                = 120,
+  $gr_django_init_provider                = $::graphite::params::gr_django_init_provider,
+  $gr_django_init_command                 = $::graphite::params::gr_django_init_command,
   $gr_django_tagging_pkg                  = $::graphite::params::django_tagging_pkg,
   $gr_django_tagging_ver                  = $::graphite::params::django_tagging_ver,
   $gr_django_tagging_source               = $::graphite::params::django_tagging_source,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -442,7 +442,7 @@
 #   Default: 'posix'
 # [*gr_django_init_command]
 #   Command to use for the Django DB initialization exec.
-#   default: "${::graphite::gr_python_binary} manage.py syncdb --noinput"
+#   default: "${::graphite::params::python_binary} manage.py syncdb --noinput"
 # [*gr_django_tagging_pkg*]
 #   String. The name of the django tagging package to install
 #   Default: django-tagging
@@ -738,8 +738,8 @@ class graphite (
   $wsgi_processes                         = 5,
   $wsgi_threads                           = 5,
   $wsgi_inactivity_timeout                = 120,
-  $gr_django_init_provider                = "${::graphite::params::gr_python_binary} manage.py syncdb --noinput",
-  $gr_django_init_command                 = $::graphite::params::django_init_command,
+  $gr_django_init_provider                = $::graphite::params::django_init_provider,
+  $gr_django_init_command                 = "${::graphite::params::python_binary} manage.py syncdb --noinput",
   $gr_django_tagging_pkg                  = $::graphite::params::django_tagging_pkg,
   $gr_django_tagging_ver                  = $::graphite::params::django_tagging_ver,
   $gr_django_tagging_source               = $::graphite::params::django_tagging_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,6 +37,10 @@ class graphite::params {
 
   $install_prefix     = '/opt/'
 
+  # variables for django db initialization
+  $gr_django_init_provider = 'posix'
+  $gr_django_init_command  = "${::graphite::gr_python_binary} manage.py syncdb --noinput"
+
   # variables to workaround unusual graphite install target:
   # https://github.com/graphite-project/carbon/issues/86
   $pyver              = $::osfamily ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,7 +39,6 @@ class graphite::params {
 
   # variables for django db initialization
   $django_init_provider = 'posix'
-#  $django_init_command  = "${::graphite::gr_python_binary} manage.py syncdb --noinput"
 
   # variables to workaround unusual graphite install target:
   # https://github.com/graphite-project/carbon/issues/86

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,8 +38,8 @@ class graphite::params {
   $install_prefix     = '/opt/'
 
   # variables for django db initialization
-  $gr_django_init_provider = 'posix'
-  $gr_django_init_command  = "${::graphite::gr_python_binary} manage.py syncdb --noinput"
+  $django_init_provider = 'posix'
+#  $django_init_command  = "${::graphite::gr_python_binary} manage.py syncdb --noinput"
 
   # variables to workaround unusual graphite install target:
   # https://github.com/graphite-project/carbon/issues/86


### PR DESCRIPTION
Hi,
I recently upgraded our graphite installations to newest stable version (1.0.2), for this I needed to upgrade Django to a higher version, where "manage.py" doesn't exist anymore, which caused issues with the way you handle initial creation of the Django DB.

With this patch, that simply adds a few parameters in the 'Initial django db creation' exec I was able to make it work. I am not sure about the naming scheme, so please take a look at it and let me know if I should change anything.

Thank you!

Reopened this PR that I intially made against the master branch.