### PR TITLE
Add a new parameter: gr_carbonlink_hashing_type (graphite-web 0.9.16+).

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,10 @@ Default is undef (array). Array of webbapp hosts. eg.: ['10.0.2.2:80', '10.0.2.3
 
 Default is undef (array). Array of carbonlink hosts. eg.: ['10.0.2.2:80', '10.0.2.3:80']
 
+##### `gr_carbonlink_hashing_type`
+
+Default is 'undef' (string). Defines consistent-hashing type for 0.9.16+, e.g.: 'carbon_ch'
+
 ##### `gr_cluster_fetch_timeout`
 
 Default is 6. Timeout to fetch series data.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -322,6 +322,9 @@
 # [*gr_carbonlink_query_bulk*]
 #   Boolean. 0.9.13 function. Using 'query-bulk' queries for carbon.
 #   Default: false
+# [*gr_carbonlink_hashing_type*]
+#   String. 0.9.16 function. Defining 'consistent-hashing' type.
+#   Default: carbon_ch
 # [*gr_cluster_fetch_timeout*]
 #   Timeout to fetch series data.   Default = 6
 # [*gr_cluster_find_timeout*]
@@ -761,6 +764,7 @@ class graphite (
   $gr_disable_webapp_cache                = false,
   $gr_enable_logrotation                  = true,
   $gr_carbonlink_query_bulk               = undef,
+  $gr_carbonlink_hashing_type             = undef,
   $gr_carbonlink_hosts_timeout            = '1.0',
   $gr_rendering_hosts                     = undef,
   $gr_rendering_hosts_timeout             = '1.0',

--- a/templates/opt/graphite/webapp/graphite/local_settings.py.erb
+++ b/templates/opt/graphite/webapp/graphite/local_settings.py.erb
@@ -286,6 +286,21 @@ CARBONLINK_TIMEOUT = <%= scope.lookupvar('graphite::gr_carbonlink_hosts_timeout'
 CARBONLINK_QUERY_BULK = <%= scope.lookupvar('graphite::gr_carbonlink_query_bulk') %>
 <% end -%>
 
+<%- if scope.lookupvar('graphite::gr_graphite_ver') >= '0.9.16' -%>
+# Type of metric hashing function.
+# The default `carbon_ch` is Graphite's traditional consistent-hashing implementation.
+# Alternatively, you can use `fnv1a_ch`, which supports the Fowler-Noll-Vo hash
+# function (FNV-1a) hash implementation offered by the carbon-c-relay project
+# https://github.com/grobian/carbon-c-relay
+#
+# Supported values: carbon_ch, fnv1a_ch
+#
+#CARBONLINK_HASHING_TYPE = 'carbon_ch'
+<% unless [:undef, nil].include? scope.lookupvar('graphite::gr_carbonlink_hashing_type') -%>
+CARBONLINK_HASHING_TYPE = '<%= scope.lookupvar('graphite::gr_carbonlink_hashing_type') %>'
+<% end -%>
+<% end -%>
+
 #####################################
 # Additional Django Settings #
 #####################################


### PR DESCRIPTION
Introduce new hashing algorithm supported by carbon-c-relay (`fnv1a_ch`). Requires graphite-web 0.9.16+, defaults to `carbon_ch`.