### PR TITLE
graphite.metrics.search removed from graphite 1.0

### DIFF
--- a/templates/opt/graphite/conf/graphite.wsgi.erb
+++ b/templates/opt/graphite/conf/graphite.wsgi.erb
@@ -41,9 +41,3 @@ if whitenoise:
         directory = os.path.join(os.path.dirname(module.__file__), 'static')
         if os.path.isdir(directory):
             application.add_files(directory, prefix=prefix)
-
-# Initializing the search index can be very expensive. The import below
-# ensures the index is preloaded before any requests are handed to the
-# process.
-log.info("graphite.wsgi - pid %d - reloading search index" % os.getpid())
-import graphite.metrics.search  # noqa


### PR DESCRIPTION
See https://github.com/graphite-project/graphite-web/commit/8187904ee03655390ab2561cea21d573a371d12b#diff-46c6eecf33ea420f578e510fc1a5a170

This fixes #349 