### PR TITLE
Update params.pp for Debian 9

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,6 +75,7 @@ class graphite::params {
         'python-psycopg2',
         'python-simplejson',
         'python-sqlite',
+        'python-setuptools',
       ]
 
       if $::operatingsystem == 'Ubuntu' {
@@ -99,7 +100,7 @@ class graphite::params {
           $extra_pip_install_options = undef
         }
 
-        /jessie|trusty|utopic|vivid|wily/: {
+        /stretch|jessie|trusty|utopic|vivid|wily/: {
           $apache_24                 = true
           $graphitepkgs              = union($common_os_pkgs, ['python-cairo',])
           $libpath                   = "/usr/lib/python${pyver}/dist-packages"


### PR DESCRIPTION
Added support for Debian 9, aka stretch
Pip needs python-setuptools to install the required pip modules.