### PR TITLE
Add support and tests for graphite-web 1.0 cluster config values

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -818,6 +818,9 @@ class graphite (
   $graphiteweb_storage_dir_REAL     = $gr_graphiteweb_storage_dir
   $graphiteweb_install_lib_dir_REAL = pick($gr_graphiteweb_install_lib_dir, "${graphiteweb_webapp_dir_REAL}/graphite")
 
+  # Check for Graphite version 1 and above
+  $version_1 = versioncmp($gr_graphite_ver, '1.0')
+
   # The anchor resources allow the end user to establish relationships
   # to the "main" class and preserve the relationship to the
   # implementation classes through a transitive relationship to

--- a/spec/classes/graphite_spec.rb
+++ b/spec/classes/graphite_spec.rb
@@ -7,6 +7,40 @@ describe 'graphite', :type => 'class' do
     it { is_expected.to raise_error(Puppet::Error,/unsupported os,.+\./ )}
   end
 
+  shared_context 'Graphite 0.9 cluster settings' do
+    let(:params) {{
+      :gr_graphite_ver => '0.9.16',
+      :gr_cluster_servers => [ '10.0.0.1', '10.0.0.2' ],
+      :gr_cluster_fetch_timeout => 6,
+      :gr_cluster_find_timeout => 2,
+      :gr_cluster_retry_delay => 10,
+      :gr_cluster_cache_duration => 120,
+    }}
+
+    it { is_expected.to contain_file('/opt/graphite/webapp/graphite/local_settings.py').with_content(/REMOTE_STORE_FETCH_TIMEOUT = 6/) }
+    it { is_expected.to contain_file('/opt/graphite/webapp/graphite/local_settings.py').with_content(/REMOTE_STORE_FIND_TIMEOUT = 2/) }
+    it { is_expected.to contain_file('/opt/graphite/webapp/graphite/local_settings.py').with_content(/REMOTE_STORE_RETRY_DELAY = 10/) }
+    it { is_expected.to contain_file('/opt/graphite/webapp/graphite/local_settings.py').with_content(/REMOTE_FIND_CACHE_DURATION = 120/) }
+
+  end
+
+  shared_context 'Graphite 1.0 cluster settings' do
+    let(:params) {{
+      :gr_graphite_ver => '1.1.1',
+      :gr_cluster_servers => [ '10.0.0.1', '10.0.0.2' ],
+      :gr_cluster_fetch_timeout => 6,
+      :gr_cluster_find_timeout => 2,
+      :gr_cluster_retry_delay => 10,
+      :gr_cluster_cache_duration => 120,
+    }}
+
+    it { is_expected.to contain_file('/opt/graphite/webapp/graphite/local_settings.py').with_content(/REMOTE_FETCH_TIMEOUT = 6/) }
+    it { is_expected.to contain_file('/opt/graphite/webapp/graphite/local_settings.py').with_content(/REMOTE_FIND_TIMEOUT = 2/) }
+    it { is_expected.to contain_file('/opt/graphite/webapp/graphite/local_settings.py').with_content(/REMOTE_RETRY_DELAY = 10/) }
+    it { is_expected.to contain_file('/opt/graphite/webapp/graphite/local_settings.py').with_content(/FIND_CACHE_DURATION = 120/) }
+
+  end
+
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
@@ -19,6 +53,9 @@ describe 'graphite', :type => 'class' do
       it { is_expected.to contain_class('graphite::install').that_notifies('Class[graphite::config]') }
       it { is_expected.to contain_class('graphite::config').that_comes_before('Anchor[graphite::end]') }
       it { is_expected.to contain_anchor('graphite::end') }
+
+      it_behaves_like 'Graphite 0.9 cluster settings'
+      it_behaves_like 'Graphite 1.0 cluster settings'
 
     end
   end

--- a/templates/opt/graphite/webapp/graphite/local_settings.py.erb
+++ b/templates/opt/graphite/webapp/graphite/local_settings.py.erb
@@ -233,10 +233,18 @@ DATABASES = {
 <% else %>
 CLUSTER_SERVERS = ['<%= scope.lookupvar('graphite::gr_cluster_servers').join("','") %>']
 
+<% if scope.lookupvar('graphite::version_1') >= 0 %>
+REMOTE_FETCH_TIMEOUT = <%= scope.lookupvar('graphite::gr_cluster_fetch_timeout') %>
+REMOTE_FIND_TIMEOUT = <%= scope.lookupvar('graphite::gr_cluster_find_timeout') %>
+REMOTE_RETRY_DELAY = <%= scope.lookupvar('graphite::gr_cluster_retry_delay') %>
+FIND_CACHE_DURATION = <%= scope.lookupvar('graphite::gr_cluster_cache_duration') %>
+<% else %>
 REMOTE_STORE_FETCH_TIMEOUT = <%= scope.lookupvar('graphite::gr_cluster_fetch_timeout') %>
 REMOTE_STORE_FIND_TIMEOUT = <%= scope.lookupvar('graphite::gr_cluster_find_timeout') %>
 REMOTE_STORE_RETRY_DELAY = <%= scope.lookupvar('graphite::gr_cluster_retry_delay') %>
 REMOTE_FIND_CACHE_DURATION = <%= scope.lookupvar('graphite::gr_cluster_cache_duration') %>
+<% end %>
+
 <% end %>
 
 ## Prefetch cache

--- a/templates/opt/graphite/webapp/graphite/local_settings.py.erb
+++ b/templates/opt/graphite/webapp/graphite/local_settings.py.erb
@@ -230,9 +230,12 @@ DATABASES = {
 #REMOTE_STORE_FIND_TIMEOUT = 2.5  # Timeout for metric find requests
 #REMOTE_STORE_RETRY_DELAY = 60    # Time before retrying a failed remote webapp
 #REMOTE_FIND_CACHE_DURATION = 300 # Time to cache remote metric find results
+
 <% else %>
 CLUSTER_SERVERS = ['<%= scope.lookupvar('graphite::gr_cluster_servers').join("','") %>']
 
+# Remote cluster settings config names changed in Graphite 1.0.
+# See https://github.com/echocat/puppet-graphite/pull/356 for more info
 <% if scope.lookupvar('graphite::version_1') >= 0 %>
 REMOTE_FETCH_TIMEOUT = <%= scope.lookupvar('graphite::gr_cluster_fetch_timeout') %>
 REMOTE_FIND_TIMEOUT = <%= scope.lookupvar('graphite::gr_cluster_find_timeout') %>


### PR DESCRIPTION
In graphite 1.0, the names of config values for remote webapps changed:

REMOTE_STORE_FETCH_TIMEOUT became REMOTE_FETCH_TIMEOUT
REMOTE_STORE_FIND_TIMEOUT became REMOTE_FIND_TIMEOUT
REMOTE_STORE_RETRY_DELAY became REMOTE_RETRY_DELAY
REMOTE_FIND_CACHE_DURATION became FIND_CACHE_DURATION

This PR sets the name of the config values, and adds tests for each of them. However, I'm not sure the way I've done it fits in well with the existing code. I'm happy to modify this based on your feedback.

- Should there be some comments in local_settings.py.erb to explain the behaviour
- Is the variable naming appropriate?
- Is the location of the tests correct? I didn't see any other examples of testing different parameters applied to the init class.

Thanks!