### PR TITLE
Fix init scripts that never stop

### DIFF
--- a/templates/etc/init.d/RedHat/carbon-aggregator.erb
+++ b/templates/etc/init.d/RedHat/carbon-aggregator.erb
@@ -97,12 +97,11 @@ restart() {
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
 
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop;
-        sleep 3
-        while [ -f ${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
-            echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
-            sleep 5
-            #TODO: add timer to prevend endless waiting
-        done
+        if [ `sleep 3; /usr/bin/pgrep -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}" | /usr/bin/wc -l` -gt 0 ]; then
+            echo "Carbon did not stop yet. Sleeping longer, then force killing it...";
+            sleep 20;
+            /usr/bin/pkill -9 -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}";
+        fi;
         rm -f /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
         echo -n $"Stopping carbon-${CARBON_DAEMON}:${INSTANCE}..."
         echo_success

--- a/templates/etc/init.d/RedHat/carbon-aggregator.erb
+++ b/templates/etc/init.d/RedHat/carbon-aggregator.erb
@@ -42,7 +42,7 @@ start()
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
         # check if instance is already running
         rh_status_q && continue
-        
+
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start;
         retval=$?
         pidfile=${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
@@ -71,14 +71,13 @@ stop()
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
         # check if instance is already stopped
         rh_status_q || continue
-        
+
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop;
-        sleep 3
-        while [ -f ${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
-            echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
-            sleep 5
-            #TODO: add timer to prevend endless waiting
-        done
+        if [ `sleep 3; /usr/bin/pgrep -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}" | /usr/bin/wc -l` -gt 0 ]; then
+            echo "Carbon did not stop yet. Sleeping longer, then force killing it...";
+            sleep 20;
+            /usr/bin/pkill -9 -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}";
+        fi;
         rm -f /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
         echo -n $"Stopping carbon-${CARBON_DAEMON}:${INSTANCE}..."
         echo_success
@@ -96,7 +95,7 @@ restart() {
         fi;
         pidfile=${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
-        
+
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop;
         sleep 3
         while [ -f ${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
@@ -108,7 +107,7 @@ restart() {
         echo -n $"Stopping carbon-${CARBON_DAEMON}:${INSTANCE}..."
         echo_success
         echo
-        
+
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start;
         retval=$?
         pidfile=${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid

--- a/templates/etc/init.d/RedHat/carbon-cache.erb
+++ b/templates/etc/init.d/RedHat/carbon-cache.erb
@@ -42,11 +42,11 @@ start()
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
         # check if instance is already running
         rh_status_q && continue
-        
+
         # If installed from source use this
         CARBON_PY=${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py
         # else use /user/bin/carbon-cache
-        
+
         ${PYTHON_CMD} ${CARBON_PY} --instance=${INSTANCE} start;
         retval=$?
         pidfile=${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
@@ -75,14 +75,13 @@ stop()
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
         # check if instance is already stopped
         rh_status_q || continue
-        
+
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop;
-        sleep 3
-        while [ -f ${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
-            echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
-            sleep 5
-            #TODO: add timer to prevend endless waiting
-        done
+        if [ `sleep 3; /usr/bin/pgrep -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}" | /usr/bin/wc -l` -gt 0 ]; then
+            echo "Carbon did not stop yet. Sleeping longer, then force killing it...";
+            sleep 20;
+            /usr/bin/pkill -9 -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}";
+        fi;
         rm -f /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
         echo -n $"Stopping carbon-${CARBON_DAEMON}:${INSTANCE}..."
         echo_success
@@ -100,7 +99,7 @@ restart() {
         fi;
         pidfile=${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
-        
+
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop;
         sleep 3
         while [ -f ${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
@@ -112,7 +111,7 @@ restart() {
         echo -n $"Stopping carbon-${CARBON_DAEMON}:${INSTANCE}..."
         echo_success
         echo
-        
+
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start;
         retval=$?
         pidfile=${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid

--- a/templates/etc/init.d/RedHat/carbon-cache.erb
+++ b/templates/etc/init.d/RedHat/carbon-cache.erb
@@ -101,12 +101,11 @@ restart() {
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
 
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop;
-        sleep 3
-        while [ -f ${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
-            echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
-            sleep 5
-            #TODO: add timer to prevend endless waiting
-        done
+        if [ `sleep 3; /usr/bin/pgrep -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}" | /usr/bin/wc -l` -gt 0 ]; then
+            echo "Carbon did not stop yet. Sleeping longer, then force killing it...";
+            sleep 20;
+            /usr/bin/pkill -9 -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}";
+        fi;
         rm -f /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
         echo -n $"Stopping carbon-${CARBON_DAEMON}:${INSTANCE}..."
         echo_success

--- a/templates/etc/init.d/RedHat/carbon-relay.erb
+++ b/templates/etc/init.d/RedHat/carbon-relay.erb
@@ -100,12 +100,11 @@ restart() {
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}
 
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop;
-        sleep 3
-        while [ -f ${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
-            echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
-            sleep 5
-            #TODO: add timer to prevend endless waiting
-        done
+        if [ `sleep 3; /usr/bin/pgrep -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}" | /usr/bin/wc -l` -gt 0 ]; then
+            echo "Carbon did not stop yet. Sleeping longer, then force killing it...";
+            sleep 20;
+            /usr/bin/pkill -9 -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}";
+        fi;
         rm -f /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
         echo -n $"Stopping carbon-${CARBON_DAEMON}:${INSTANCE}..."
         echo_success

--- a/templates/etc/init.d/RedHat/carbon-relay.erb
+++ b/templates/etc/init.d/RedHat/carbon-relay.erb
@@ -76,12 +76,11 @@ stop()
         rh_status_q || continue
 
         ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} stop;
-        sleep 3
-        while [ -f ${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid ]; do
-            echo "waiting another 5 secs for carbon-${CARBON_DAEMON}-${INSTANCE} to stop"
-            sleep 5
-            #TODO: add timer to prevend endless waiting
-        done
+        if [ `sleep 3; /usr/bin/pgrep -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}" | /usr/bin/wc -l` -gt 0 ]; then
+            echo "Carbon did not stop yet. Sleeping longer, then force killing it...";
+            sleep 20;
+            /usr/bin/pkill -9 -f "carbon-${CARBON_DAEMON}.py --instance=${INSTANCE}";
+        fi;
         rm -f /var/lock/subsys/carbon-${CARBON_DAEMON}-${INSTANCE}
         echo -n $"Stopping carbon-${CARBON_DAEMON}:${INSTANCE}..."
         echo_success


### PR DESCRIPTION
I'm not sure how you'd like to handle this, but this is an attempt to fix just the stop portion of the init scripts which never exit or shut down cleanly (ref: https://github.com/echocat/puppet-graphite/blob/master/templates/etc/init.d/RedHat/carbon-relay.erb#L83), pulled pieces directly from [graphite-project](https://github.com/graphite-project/carbon/tree/master/distro/redhat)