### PR TITLE
Update carbon-logrotate - ignore unrotated files

### DIFF
--- a/templates/opt/graphite/bin/carbon-logrotate.sh.erb
+++ b/templates/opt/graphite/bin/carbon-logrotate.sh.erb
@@ -12,7 +12,7 @@ RETENTION=30
 for CARBON_LOG in $CARBON_LOGS; do
   if [ -d "${CARBON_LOGS_PATH}/${CARBON_LOG}" ]; then
     # gzip log files older than $ROTATE_DAYS days
-    find "${CARBON_LOGS_PATH}/${CARBON_LOG}" -type f -mtime +${ROTATE_DAYS} ! -name "*.gz" -exec gzip -q "{}" \;
+    find "${CARBON_LOGS_PATH}/${CARBON_LOG}" -type f -mtime +${ROTATE_DAYS} -name "*.log.????_*" ! -name "*.gz" -exec gzip -q "{}" \;
     # removes log files older than $RETENTION days
     find "${CARBON_LOGS_PATH}/${CARBON_LOG}" -type f -ctime +${RETENTION} -delete
   fi


### PR DESCRIPTION
By default carbon-logrotate will attempt to compress files that haven't been rotated or updated by carbon in over 3 days. This will eventually begin to fail as it cannot gzip over the same name (we see this happening most often on listener.log)

This seems to happen because carbon doesn't do the file rotation until the next line is added to the log. 

This change will only attempt to compress files that carbon has actually rotated