### PR TITLE
Initial django db creation example for Django >=1.7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -447,7 +447,8 @@
 #   Command to use for the Django DB initialization exec.
 #   default: "${::graphite::params::python_binary} manage.py syncdb --noinput"
 #   Since Django 1.7 sysndb is deprecated and the command should be
-#   "${::graphite::params::python_binary} manage.py migrate --run-syncd"
+#   "${::graphite::params::python_binary} manage.py migrate --run-syncd" or
+#   'django-admin migrate --settings=graphite.settings --run-syncdb'
 # [*gr_django_tagging_pkg*]
 #   String. The name of the django tagging package to install
 #   Default: django-tagging

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -446,6 +446,8 @@
 # [*gr_django_init_command]
 #   Command to use for the Django DB initialization exec.
 #   default: "${::graphite::params::python_binary} manage.py syncdb --noinput"
+#   Since Django 1.7 sysndb is deprecated and the command should be
+#   "${::graphite::params::python_binary} manage.py migrate --run-syncd"
 # [*gr_django_tagging_pkg*]
 #   String. The name of the django tagging package to install
 #   Default: django-tagging


### PR DESCRIPTION
syncdb is deprecated and an example is required
https://docs.djangoproject.com/en/1.8/ref/django-admin/#syncdb

A library could be created to check for the version of the Django repo available in Debian or RedHat and to set the command dynamically.