### PR TITLE
Debian init script fix

### DIFF
--- a/templates/etc/init.d/Debian/carbon-cache.erb
+++ b/templates/etc/init.d/Debian/carbon-cache.erb
@@ -61,7 +61,7 @@ case "${OPERATION}" in
                 INSTANCE="a";
             fi;
             ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} status
-            let rc=${rc}+$?
+	    rc=$((${rc}+${?}))
         done
         exit ${rc}
         ;;


### PR DESCRIPTION
"let" is not available in sh/dash :

```
# /etc/init.d/carbon-cache status
carbon-cache (instance a) is running with pid 6092
/etc/init.d/carbon-cache: 64: /etc/init.d/carbon-cache: let: not found
```

Rewrite expression using arithmetic, tested on debian with dash (default sh provider for Debian)