### PR TITLE
Switch for the queue sorts log data

### DIFF
--- a/README.md
+++ b/README.md
@@ -873,6 +873,10 @@ Default is false. Set fallocate_create for whisper
 
 Default is 'False' (string). Logs timings for remote calls to carbon-cache
 
+##### `gr_log_cache_queue_sorts`
+
+Default is 'True' (String). Logs time required for the queue sorts
+
 ##### `gr_log_rendering_performance`
 
 Default is 'False' (string). Triggers the creation of rendering.log which logs timings for calls to the The Render URL API

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -429,6 +429,9 @@
 # [*gr_log_cache_performance*]
 #   logs timings for remote calls to carbon-cache
 #   Default is 'False' (String)
+# [*gr_log_cache_queue_sorts]
+#   Logs time required for the queue sorts
+#   Default is 'True' (String)
 # [*gr_log_rendering_performance*]
 #   Triggers the creation of rendering.log which logs timings for calls to
 #   the The Render URL API
@@ -746,6 +749,7 @@ class graphite (
   $gr_whisper_lock_writes                 = 'False',
   $gr_whisper_fallocate_create            = 'False',
   $gr_log_cache_performance               = 'False',
+  $gr_log_cache_queue_sorts               = 'False',
   $gr_log_rendering_performance           = 'False',
   $gr_log_metric_access                   = 'False',
   $wsgi_processes                         = 5,

--- a/templates/opt/graphite/conf/carbon.conf.erb
+++ b/templates/opt/graphite/conf/carbon.conf.erb
@@ -112,7 +112,7 @@ USE_FLOW_CONTROL = True
 # degrade performance if logging on the same volume as the whisper data is stored.
 LOG_UPDATES = False
 LOG_CACHE_HITS = False
-LOG_CACHE_QUEUE_SORTS = True
+LOG_CACHE_QUEUE_SORTS = <%= scope.lookupvar('graphite::gr_log_cache_queue_sorts') %>
 
 # The thread that writes metrics to disk can use on of the following strategies
 # determining the order in which metrics are removed from cache and flushed to


### PR DESCRIPTION
LOG_CACHE_QUEUE_SORTS generates a huge amount of log data for large deployments