### PR TITLE
360 graphite 1 1

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -131,6 +131,16 @@ class graphite::config inherits graphite::params {
     seltype   => 'httpd_sys_rw_content_t',
     subscribe => Exec['Initial django db creation'],
   }
+  file { [
+    "${::graphite::graphiteweb_log_dir_REAL}/info.log",
+    "${::graphite::graphiteweb_log_dir_REAL}/exception.log"]:
+    ensure    => file,
+    group     => $gr_web_group_REAL,
+    mode      => '0755',
+    owner     => $gr_web_user_REAL,
+    seltype   => 'httpd_sys_rw_content_t',
+    subscribe => Exec['Initial django db creation'],
+  }
 
   # change access permissions for carbon-cache to align with gr_user
   # (if different from web_user)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -130,29 +130,29 @@ class graphite::install inherits graphite::params {
     $carbon = "carbon-${::graphite::gr_carbon_ver}-py${::graphite::params::pyver}.egg-info"
     $gweb = "graphite_web-${::graphite::gr_graphite_ver}-py${::graphite::params::pyver}.egg-info"
     exec{ 'gweb_hack':
-        command => "ln -s '${::graphite::base_dir_REAL}/webapp/${gweb}' '${::graphite::params::libpath}/'",
-        unless      => "test -L '${::graphite::params::libpath}/${gweb}'",
-        provider    => 'shell',
+        command   => "ln -s '${::graphite::base_dir_REAL}/webapp/${gweb}' '${::graphite::params::libpath}/'",
+        unless    => "test -L '${::graphite::params::libpath}/${gweb}'",
+        provider  => 'shell',
         subscribe => Package['graphite-web']
     }
     exec{ 'carbon_hack':
-        command     => "ln -s '${::graphite::base_dir_REAL}/lib/${carbon}' '${::graphite::params::libpath}/'",
-        unless      => "test -L '${::graphite::params::libpath}/${carbon}'",
-        provider    => 'shell',
+        command   => "ln -s '${::graphite::base_dir_REAL}/lib/${carbon}' '${::graphite::params::libpath}/'",
+        unless    => "test -L '${::graphite::params::libpath}/${carbon}'",
+        provider  => 'shell',
         subscribe => Package['carbon']
     }
     # Purge duplicate egg-info files having the wrong version
     exec{ 'Purge old graphite-web egg-info':
         command   => "find '${::graphite::base_dir_REAL}/webapp' '${::graphite::params::libpath}' -iname 'graphite_web-*.egg-info' -not  -iname '${gweb}' | xargs rm -rf",
         onlyif    => "ls -d \"${::graphite::base_dir_REAL}/webapp/\"graphite_web*.egg-info \"${::graphite::params::libpath}/\"graphite_web*.egg-info | grep -v '${gweb}'",
-        path      => "/bin:/usr/bin",
+        path      => '/bin:/usr/bin',
         provider  => 'shell',
         subscribe => Package['graphite-web']
     }
     exec{ 'Purge old carbon egg-info':
         command   => "find '${::graphite::base_dir_REAL}/lib' '${::graphite::params::libpath}' -iname 'carbon-*.egg-info' -not  -iname '${carbon}' | xargs rm -rf",
         onlyif    => "ls -d \"${::graphite::base_dir_REAL}/lib/\"carbon*.egg-info \"${::graphite::params::libpath}/\"carbon*.egg-info | grep -v '${carbon}'",
-        path      => "/bin:/usr/bin",
+        path      => '/bin:/usr/bin',
         provider  => 'shell',
         subscribe => Package['carbon']
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -127,23 +127,34 @@ class graphite::install inherits graphite::params {
     }
 
     # hack unusual graphite install target
-    $carbon = "\"carbon-\"*\"-py${::graphite::params::pyver}.egg-info\""
-    $gweb = "\"graphite_web-\"*\"-py${::graphite::params::pyver}.egg-info\""
-    create_resources('exec', {
-      'carbon_hack' => {
-        command => "ln -s \"${::graphite::base_dir_REAL}/lib/\"${carbon} \"${::graphite::params::libpath}/\""
-      }
-      ,
-      'gweb_hack'   => {
-        command => "ln -s \"${::graphite::base_dir_REAL}/webapp/\"${gweb} \"${::graphite::params::libpath}/\""
-      }
-      ,
+    $carbon = "carbon-${::graphite::gr_carbon_ver}-py${::graphite::params::pyver}.egg-info"
+    $gweb = "graphite_web-${::graphite::gr_graphite_ver}-py${::graphite::params::pyver}.egg-info"
+    exec{ 'gweb_hack':
+        command => "ln -s '${::graphite::base_dir_REAL}/webapp/${gweb}' '${::graphite::params::libpath}/'",
+        unless      => "test -L '${::graphite::params::libpath}/${gweb}'",
+        provider    => 'shell',
+        subscribe => Package['graphite-web']
     }
-    , {
-      refreshonly => true,
-      subscribe   => Package['carbon', 'graphite-web', 'whisper'],
-      provider    => 'shell',
+    exec{ 'carbon_hack':
+        command     => "ln -s '${::graphite::base_dir_REAL}/lib/${carbon}' '${::graphite::params::libpath}/'",
+        unless      => "test -L '${::graphite::params::libpath}/${carbon}'",
+        provider    => 'shell',
+        subscribe => Package['carbon']
     }
-    )
+    # Purge duplicate egg-info files having the wrong version
+    exec{ 'Purge old graphite-web egg-info':
+        command   => "find '${::graphite::base_dir_REAL}/webapp' '${::graphite::params::libpath}' -iname 'graphite_web-*.egg-info' -not  -iname '${gweb}' | xargs rm -rf",
+        onlyif    => "ls -d \"${::graphite::base_dir_REAL}/webapp/\"graphite_web*.egg-info \"${::graphite::params::libpath}/\"graphite_web*.egg-info | grep -v '${gweb}'",
+        path      => "/bin:/usr/bin",
+        provider  => 'shell',
+        subscribe => Package['graphite-web']
+    }
+    exec{ 'Purge old carbon egg-info':
+        command   => "find '${::graphite::base_dir_REAL}/lib' '${::graphite::params::libpath}' -iname 'carbon-*.egg-info' -not  -iname '${carbon}' | xargs rm -rf",
+        onlyif    => "ls -d \"${::graphite::base_dir_REAL}/lib/\"carbon*.egg-info \"${::graphite::params::libpath}/\"carbon*.egg-info | grep -v '${carbon}'",
+        path      => "/bin:/usr/bin",
+        provider  => 'shell',
+        subscribe => Package['carbon']
+    }
   }
 }

--- a/spec/acceptance/nodesets/docker.yml
+++ b/spec/acceptance/nodesets/docker.yml
@@ -1,0 +1,25 @@
+HOSTS:
+  graphite-0.9:
+    roles:
+      - default
+      - graphite_1
+    platform: ubuntu-1804-x86_64
+    image: ubuntu:bionic
+    hypervisor: docker
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+    - 'apt install -y init cron iproute2 libffi-dev netcat-openbsd'
+
+  graphite-1.1-fresh:
+    roles:
+      - graphite_1
+    platform: ubuntu-1804-x86_64
+    image: ubuntu:bionic
+    hypervisor: docker
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+    - 'apt install -y init cron iproute2 libffi-dev netcat-openbsd'
+
+
+CONFIG:
+    type: foss

--- a/spec/acceptance/x_gr_1_inst_up_spec.rb
+++ b/spec/acceptance/x_gr_1_inst_up_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper_acceptance'
+
+hosts_as('graphite_1').each do |graphite_host|
+
+  describe "install/update to Graphite 1.1 on host #{graphite_host}" do
+    let(:graphite_version){ '1.1.7' }
+    let(:django_version){ '1.11' }
+    let(:django_tagging_version){ '0.4.6' }
+    let(:twisted_version){ '20.3.0' }
+
+    it 'has to delete the existing django db to work around failures migrating the database from 0.9' do
+      on(graphite_host, 'rm -f /opt/graphite/storage/graphite.db || exit 0')
+    end
+
+    context 'install or upgrade Graphite' do
+      # Using puppet_apply as a helper
+      it 'should apply with no errors' do
+        pp = <<-EOS
+          class { 'graphite': 
+                secret_key                => '123456789', 
+                gr_base_dir               => '/opt/graphite',
+                gr_django_init_command    => 'PYTHONPATH=/opt/graphite/webapp /usr/local/bin/django-admin.py migrate --setting=graphite.settings --fake-initial',
+                gr_django_init_provider   => 'shell',
+                gr_carbon_ver             => '#{graphite_version}',
+                gr_graphite_ver           => '#{graphite_version}',
+                gr_whisper_ver            => '#{graphite_version}',
+                gr_django_ver             => '#{django_version}',
+                gr_django_tagging_ver     => '#{django_tagging_version}',
+                gr_twisted_ver            => '#{twisted_version}',
+          }
+        EOS
+
+        apply_manifest_on(graphite_host, pp, :catch_failures => true)
+      end
+
+      it 'should send metric data to carbon' do
+        result = on(graphite_host, 'echo "one.metric 42 `date +%s`" | nc -N 127.0.0.1 2003')
+        expect(result.exit_code).to eq 0
+      end
+
+      it 'should get data from graphite' do
+        result = on(graphite_host, "sleep 10 && curl -s 'http://127.0.0.1/render?target=one.metric&format=raw&from=-5min' | grep 'one.metric,.*42.0'")
+        expect(result.exit_code).to eq 0
+      end
+
+      it 'exist only one link to the egg-info of graphite in the python lib directory' do
+        result = on(graphite_host, "test `ls -d /usr/local/lib/python2.7/dist-packages/graphite_web*.egg-info | wc -l` -eq 1")
+        expect(result.exit_code).to eq 0
+      end
+
+      it 'exist only one egg-info of graphite in the installation directory' do
+        result = on(graphite_host, "test `ls -d /opt/graphite/webapp/graphite_web*.egg-info | wc -l` -eq 1")
+        expect(result.exit_code).to eq 0
+      end
+
+      it 'exist only one link to the egg-info of cabon in the python lib directory' do
+        result = on(graphite_host, "test `ls -d /usr/local/lib/python2.7/dist-packages/carbon*.egg-info | wc -l` -eq 1")
+        expect(result.exit_code).to eq 0
+      end
+
+      it 'exist only one egg-info of carbon in the installation directory' do
+        result = on(graphite_host, "test `ls -d /opt/graphite/lib/carbon*.egg-info | wc -l` -eq 1")
+        expect(result.exit_code).to eq 0
+      end
+    end
+  end
+
+end

--- a/spec/classes/graphite_install_spec.rb
+++ b/spec/classes/graphite_install_spec.rb
@@ -3,10 +3,13 @@ require 'spec_helper'
 describe 'graphite::install', :type => 'class' do
 
   # Convenience variable for 'hack' file checks
-  hack_defaults = {
-    :refreshonly => true,
+  gweb_hack_defaults = {
     :provider    => 'shell',
-    :subscribe   => ['Package[carbon]','Package[graphite-web]','Package[whisper]'],
+    :subscribe   => 'Package[graphite-web]',
+  }
+  carbon_hack_defaults = {
+    :provider    => 'shell',
+    :subscribe   => 'Package[carbon]',
   }
 
   shared_context 'supported platforms' do
@@ -21,8 +24,8 @@ describe 'graphite::install', :type => 'class' do
         'Package[python-ldap]').that_requires(
         'Package[python-psycopg2]') }
     end
-    it { is_expected.to contain_exec('carbon_hack').with(hack_defaults) }
-    it { is_expected.to contain_exec('gweb_hack').with(hack_defaults) }
+    it { is_expected.to contain_exec('carbon_hack').with(carbon_hack_defaults) }
+    it { is_expected.to contain_exec('gweb_hack').with(gweb_hack_defaults) }
   end
 
   shared_context 'no pip' do
@@ -65,11 +68,13 @@ describe 'graphite::install', :type => 'class' do
     it { is_expected.to contain_package('bitmap-fonts-compat').with_provider(nil) }
     it { is_expected.to contain_package('python-crypto').with_provider(nil) }
 
-    it { is_expected.to contain_exec('carbon_hack').only_with(hack_defaults.merge({
-      :command => 'ln -s "/opt/graphite/lib/""carbon-"*"-py2.6.egg-info" "/usr/lib/python2.6/site-packages/"',
+    it { is_expected.to contain_exec('carbon_hack').only_with(carbon_hack_defaults.merge({
+      :command => "ln -s '/opt/graphite/lib/carbon-0.9.15-py2.6.egg-info' '/usr/lib/python2.6/site-packages/'",
+      :unless  => "test -L '/usr/lib/python2.6/site-packages/carbon-0.9.15-py2.6.egg-info'",
     })) }
-    it { should contain_exec('gweb_hack').only_with(hack_defaults.merge({
-      :command => 'ln -s "/opt/graphite/webapp/""graphite_web-"*"-py2.6.egg-info" "/usr/lib/python2.6/site-packages/"',
+    it { should contain_exec('gweb_hack').only_with(gweb_hack_defaults.merge({
+      :command => "ln -s '/opt/graphite/webapp/graphite_web-0.9.15-py2.6.egg-info' '/usr/lib/python2.6/site-packages/'",
+      :unless  => "test -L '/usr/lib/python2.6/site-packages/graphite_web-0.9.15-py2.6.egg-info'",
     })) }
   end
 
@@ -82,11 +87,13 @@ describe 'graphite::install', :type => 'class' do
     it { is_expected.to contain_package('dejavu-sans-fonts').with_provider(nil) }
     it { is_expected.to contain_package('python2-crypto').with_provider(nil) }
 
-    it { is_expected.to contain_exec('carbon_hack').only_with(hack_defaults.merge({
-      :command => 'ln -s "/opt/graphite/lib/""carbon-"*"-py2.7.egg-info" "/usr/lib/python2.7/site-packages/"',
+    it { is_expected.to contain_exec('carbon_hack').only_with(carbon_hack_defaults.merge({
+      :command => "ln -s '/opt/graphite/lib/carbon-0.9.15-py2.7.egg-info' '/usr/lib/python2.7/site-packages/'",
+      :unless  => "test -L '/usr/lib/python2.7/site-packages/carbon-0.9.15-py2.7.egg-info'",
     })) }
-    it { is_expected.to contain_exec('gweb_hack').only_with(hack_defaults.merge({
-      :command => 'ln -s "/opt/graphite/webapp/""graphite_web-"*"-py2.7.egg-info" "/usr/lib/python2.7/site-packages/"',
+    it { is_expected.to contain_exec('gweb_hack').only_with(gweb_hack_defaults.merge({
+      :command => "ln -s '/opt/graphite/webapp/graphite_web-0.9.15-py2.7.egg-info' '/usr/lib/python2.7/site-packages/'",
+      :unless  => "test -L '/usr/lib/python2.7/site-packages/graphite_web-0.9.15-py2.7.egg-info'",
     })) }
   end
 


### PR DESCRIPTION
I came accross during the graphite upgrade of our monitoring platform and fixed the following issues:

- set correct permissions on info and exception logs of graphite
- more stable cleanup of egg-infos in non-standard location
- added acceptance tests for graphite 1.1 installation and update

Access rights on /opt/graphite/storage/graphite.db are correct in my installations.

Regards

Frank