### PR TITLE
Change default for gr_log_cache_queue_sorts from False to True

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -755,7 +755,7 @@ class graphite (
   $gr_whisper_lock_writes                 = 'False',
   $gr_whisper_fallocate_create            = 'False',
   $gr_log_cache_performance               = 'False',
-  $gr_log_cache_queue_sorts               = 'False',
+  $gr_log_cache_queue_sorts               = 'True',
   $gr_log_rendering_performance           = 'False',
   $gr_log_metric_access                   = 'False',
   $wsgi_processes                         = 5,


### PR DESCRIPTION
The parameters description says: the default value for `gr_log_cache_queue_sorts` is 'True', but in the code it is set to 'False'. I think it should effectively be set to 'True', as in description and previous versions.