### PR TITLE
Log connection key names changed in Graphite 1.0

### DIFF
--- a/templates/opt/graphite/conf/carbon.conf.erb
+++ b/templates/opt/graphite/conf/carbon.conf.erb
@@ -92,7 +92,11 @@ PICKLE_RECEIVER_INTERFACE = <%= scope.lookupvar('graphite::gr_pickle_receiver_in
 PICKLE_RECEIVER_PORT = <%= scope.lookupvar('graphite::gr_pickle_receiver_port') %>
 
 # Set to false to disable logging of successful connections
+<% if scope.lookupvar('graphite::version_1') >= 0 -%>
+LOG_LISTENER_CONN_SUCCESS = <%= scope.lookupvar('graphite::gr_log_listener_connections') %>
+<% else -%>
 LOG_LISTENER_CONNECTIONS = <%= scope.lookupvar('graphite::gr_log_listener_connections') %>
+<% end -%>
 
 # Per security concerns outlined in Bug #817247 the pickle receiver
 # will use a more secure and slightly less efficient unpickler.
@@ -280,7 +284,11 @@ UDP_RECEIVER_INTERFACE = <%= scope.lookupvar('graphite::gr_relay_udp_receiver_in
 UDP_RECEIVER_PORT = <%= scope.lookupvar('graphite::gr_relay_udp_receiver_port') %>
 
 # Set to false to disable logging of successful connections
+<% if scope.lookupvar('graphite::version_1') >= 0 -%>
+LOG_LISTENER_CONN_SUCCESS = <%= scope.lookupvar('graphite::gr_relay_log_listener_connections') %>
+<% else -%>
 LOG_LISTENER_CONNECTIONS = <%= scope.lookupvar('graphite::gr_relay_log_listener_connections') %>
+<% end -%>
 
 # Carbon-relay has several options for metric routing controlled by RELAY_METHOD
 #
@@ -384,7 +392,11 @@ UDP_RECEIVER_INTERFACE = <%= scope.lookupvar('graphite::gr_aggregator_udp_receiv
 UDP_RECEIVER_PORT = <%= scope.lookupvar('graphite::gr_aggregator_udp_receiver_port') %>
 
 # Set to false to disable logging of successful connections
+<% if scope.lookupvar('graphite::version_1') >= 0 -%>
+LOG_LISTENER_CONN_SUCCESS = <%= scope.lookupvar('graphite::gr_aggregator_log_listener_connections') %>
+<% else -%>
 LOG_LISTENER_CONNECTIONS = <%= scope.lookupvar('graphite::gr_aggregator_log_listener_connections') %>
+<% end -%>
 
 # If set true, metric received will be forwarded to DESTINATIONS in addition to
 # the output of the aggregation rules. If set false the carbon-aggregator will


### PR DESCRIPTION
- Added conditional logic to set a valid log connection key name